### PR TITLE
Use secrets from different location

### DIFF
--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -45,10 +45,10 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/common/github.com/actions/camunda-cloud/zeebe-process-test REGISTRY_HUB_DOCKER_COM_USR;
-            secret/data/common/github.com/actions/camunda-cloud/zeebe-process-test REGISTRY_HUB_DOCKER_COM_PSW;
-            secret/data/common/github.com/actions/camunda-cloud/zeebe-process-test ARTIFACTS_USR;
-            secret/data/common/github.com/actions/camunda-cloud/zeebe-process-test ARTIFACTS_PSW;
+            secret/data/common/github.com/actions/camunda/zeebe-process-test REGISTRY_HUB_DOCKER_COM_USR;
+            secret/data/common/github.com/actions/camunda/zeebe-process-test REGISTRY_HUB_DOCKER_COM_PSW;
+            secret/data/common/github.com/actions/camunda/zeebe-process-test ARTIFACTS_USR;
+            secret/data/common/github.com/actions/camunda/zeebe-process-test ARTIFACTS_PSW;
             secret/data/common/github.com/actions/camunda-community-hub MAVEN_CENTRAL_DEPLOYMENT_USR;
             secret/data/common/github.com/actions/camunda-community-hub MAVEN_CENTRAL_DEPLOYMENT_PSW;
             secret/data/common/github.com/actions/camunda-community-hub MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE;


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The repository will be moved from the camunda-cloud organisation to the camunda organisation. The secrets we use have been made available under a different path to reflect this move.
We should use this location before the actual move. After the move the old secrets will be deleted.

More context: https://jira.camunda.com/browse/INFRA-3127

## Related issues

<!-- Which issues are closed by this PR or are related -->

Related to #250 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
