### PR TITLE
Update versions on stable branch

### DIFF
--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -10,7 +10,6 @@ on:
     branches: [main]
   release:
     types: [published]
-  workflow_dispatch: { }
 jobs:
   test:
     uses: ./.github/workflows/build-test.yml
@@ -116,9 +115,8 @@ jobs:
       # to stable/major.minor.
       - name: Decide git branch
         id: branch
-        if: github.ref != 'refs/head/main'
         run: |
-          if [[ ${{ github.event.release.tag_name }} != *"alpha"* ]]; then
+          if ! [ -z "${{ github.event.release.tag_name }}" ] && [[ ${{ github.event.release.tag_name }} != *"alpha"* ]]; then
             MAJOR_MINOR_VERSION=$(echo ${{ github.event.release.tag_name }} | sed -rn 's/^([0-9]+.[0-9]+).[0-9]+.*$/\1/p')
             test -z "${MAJOR_MINOR_VERSION}" && echo "::error::Tag ${{ github.event.release.tag_name }} does not adhere to semantic versioning" && exit 1
             echo "::set-output name=branch::stable/$MAJOR_MINOR_VERSION"

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -108,13 +108,33 @@ jobs:
           gpg_private_key: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
           passphrase: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
 
+      # We want the community-action-maven-release to update the versions on the correct branch. For
+      # this reason an extra step is introduced to decide what branch we should pass to this action.
+      # In the case of a push to the main branch, or an alpha release we should update the main branch.
+      # In other cases a stable/major.minor branch should be available. In this step we first find
+      # the major and minor versions of this tag. If we found them we will set the BRANCH env variable
+      # to stable/major.minor.
+      - name: Decide git branch
+        id: branch
+        if: github.ref != 'refs/head/main'
+        run: |
+          if [[ ${{ github.event.release.tag_name }} != *"alpha"* ]]; then
+            MAJOR_MINOR_VERSION=$(echo ${{ github.event.release.tag_name }} | sed -rn 's/^([0-9]+.[0-9]+).[0-9]+.*$/\1/p')
+            test -z "${MAJOR_MINOR_VERSION}" && echo "::error::Tag ${{ github.event.release.tag_name }} does not adhere to semantic versioning" && exit 1
+            echo "::set-output name=branch::stable/$MAJOR_MINOR_VERSION"
+            echo "Branch = stable/$MAJOR_MINOR_VERSION"
+          else
+            echo "::set-output name=branch::${{ github.event.repository.default_branch }}"
+            echo "Branch = ${{ github.event.repository.default_branch }}"
+          fi
+
         # In extension-testcontainer we have a config file which contains the image tag. This is managed by maven and
         # maven will set this to the project version in this step, unless the placeholder (${project.version}) has been
         # overridden by the "Update tag in config" step. This happens when the workflow is triggered by a change on the
         # main branch.
       - name: Build and deploy to Maven
         id: release
-        uses: camunda-community-hub/community-action-maven-release@v1.0.12
+        uses: camunda-community-hub/community-action-maven-release@v1
         with:
           release-version: ${{ github.event.release.tag_name }}
           release-profile: community-action-maven-release
@@ -125,6 +145,7 @@ jobs:
           maven-gpg-passphrase: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
           maven-url: s01.oss.sonatype.org
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ steps.branch.outputs.branch }}
 
       - name: Attach artifacts to GitHub Release (Release only)
         if: github.event.release


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The maven action plugin used to only be able to update the version on the default branch of the repository. Recently a change has been made to make the branch configurable. For this reason a step has been introduced to the workflow to decide our git branch.

It works by first figuring out what the major and minor version of the release are (e.g. 1.4 when the release is 1.4.1). If this fails to yield a result we exit the workflow. Otherwise we will add the branch (stable/major.minor) as an output of this step. This will then be used by the community-action-maven-release as the branch for updating the versions.

I've done some manual test to verify the workflow works as expected. I did this by creating a `stable/0.0` branch and creating some test release. I have deleted this branch and the releases by now, but the workflows are still available:

- Release on branch `stable/0.0` with tag `0.0.1`: https://github.com/camunda/zeebe-process-test/runs/5553684537?check_suite_focus=true
Expected the workflow to create new commits updating the version on the `stable/0.0` branch. ✅ 
- Release on branch `stable/0.0` with tag `release-0`: https://github.com/camunda/zeebe-process-test/runs/5554164842?check_suite_focus=true
Expected the workflow to fail, mentioning how the tag does not adhere to semantic versioning. ✅ 
- Release on branch `stable/0.0` with tag `0.0.1-alpha1`: https://github.com/camunda/zeebe-process-test/runs/5554214263?check_suite_focus=true
Expected the workflow to create new commits updating the version on the `main` branch. ⚠️ 
The test did not match the expectation. No new commits were created. After analysing why, the reason is that the release was created on the `stable/0.0` branch. The community-action-maven-release has a check to see if the release tag is pointing to the latest commit on the target branch (`main`). This was not the case in my test, so my expectations were wrong. I can see in the logging that the correct branch  (`main`) is being used. If the release would've been made on the `main` branch the workflow would've succeeded. Therefore, I consider this test a succes ✅ 
## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #231 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
