### PR TITLE
Check binary compatibility

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -33,4 +33,13 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/api/revapi.json
+++ b/api/revapi.json
@@ -1,0 +1,14 @@
+[
+  {
+    "extension": "revapi.filter",
+    "id": "filter",
+    "configuration": {
+      "archives": {
+        "justification": "Ignore everything not included in the module itself",
+        "include": [
+          "io\\.camunda:zeebe-process-test-api:.*"
+        ]
+      }
+    }
+  }
+]

--- a/assertions/pom.xml
+++ b/assertions/pom.xml
@@ -74,6 +74,11 @@
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/assertions/revapi.json
+++ b/assertions/revapi.json
@@ -1,0 +1,14 @@
+[
+  {
+    "extension": "revapi.filter",
+    "id": "filter",
+    "configuration": {
+      "archives": {
+        "justification": "Ignore everything not included in the module itself",
+        "include": [
+          "io\\.camunda:zeebe-process-test-assertions:.*"
+        ]
+      }
+    }
+  }
+]

--- a/extension-testcontainer/pom.xml
+++ b/extension-testcontainer/pom.xml
@@ -103,6 +103,13 @@
         <directory>src/main/resources</directory>
       </resource>
     </resources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
   </build>
 
 </project>

--- a/extension-testcontainer/revapi.json
+++ b/extension-testcontainer/revapi.json
@@ -1,0 +1,14 @@
+[
+  {
+    "extension": "revapi.filter",
+    "id": "filter",
+    "configuration": {
+      "archives": {
+        "justification": "Ignore everything not included in the module itself",
+        "include": [
+          "io\\.camunda:zeebe-process-test-extension-testonctainer:.*"
+        ]
+      }
+    }
+  }
+]

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -112,6 +112,11 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/extension/revapi.json
+++ b/extension/revapi.json
@@ -1,0 +1,14 @@
+[
+  {
+    "extension": "revapi.filter",
+    "id": "filter",
+    "configuration": {
+      "archives": {
+        "justification": "Ignore everything not included in the module itself",
+        "include": [
+          "io\\.camunda:zeebe-process-test-extension:.*"
+        ]
+      }
+    }
+  }
+]

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
     <dependency.osgi.version>6.0.0</dependency.osgi.version>
     <dependency.proto.version>2.8.0</dependency.proto.version>
     <dependency.protobuf.version>3.19.4</dependency.protobuf.version>
+    <dependency.revapi.version>0.26.1</dependency.revapi.version>
     <dependency.scala.version>2.13.8</dependency.scala.version>
     <dependency.slf4j.version>1.7.36</dependency.slf4j.version>
     <dependency.snakeyaml.version>1.30</dependency.snakeyaml.version>
@@ -88,6 +89,7 @@
     <plugin.version.license>4.1</plugin.version.license>
     <plugin.version.maven-enforcer>3.0.0</plugin.version.maven-enforcer>
     <plugin.version.os-maven>1.7.0</plugin.version.os-maven>
+    <plugin.version.revapi>0.14.6</plugin.version.revapi>
     <plugin.version.spotless>2.22.0</plugin.version.spotless>
     <plugin.version.surefire>3.0.0-M5</plugin.version.surefire>
 
@@ -430,8 +432,47 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.revapi</groupId>
+          <artifactId>revapi-maven-plugin</artifactId>
+          <version>${plugin.version.revapi}</version>
+          <configuration>
+            <!-- expands maven properties in the configuration files -->
+            <expandProperties>true</expandProperties>
+            <!-- allows us to pre-defined ignored-changes, even when missing -->
+            <failOnMissingConfigurationFiles>false</failOnMissingConfigurationFiles>
+            <analysisConfigurationFiles>
+              <!-- look for an optional relative configuration file -->
+              <configurationFile>
+                <path>revapi.json</path>
+              </configurationFile>
+              <!-- will pick up a project relative ignored-changes file -->
+              <configurationFile>
+                <path>ignored-changes.json</path>
+              </configurationFile>
+            </analysisConfigurationFiles>
+            <oldVersion>LATEST</oldVersion>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.revapi</groupId>
+              <artifactId>revapi-java</artifactId>
+              <version>${dependency.revapi.version}</version>
+            </dependency>
+          </dependencies>
+          <executions>
+            <execution>
+              <id>check</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <phase>verify</phase>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The revapi maven plugin allows us to perform API checks during our maven build. It will check the current build against the latest released version available on maven.

This tool ensures our interfaces are backwards compatibility. Since we only guarantee backwards compatibility on some of our modules it has only been added to these modules.

⚠️ We really should not check our compatibility against pre-releases. I cannot make this change part of this as it will break stuff if we do this before the 8.0.0 release. For this I have created a separate issue: #283 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #275 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
