### PR TITLE
Explicitly depend on google-java-format

### DIFF
--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -2,6 +2,6 @@
 <project version="4">
   <component name="ExternalDependencies">
     <plugin id="com.dubreuia" />
-    <plugin id="google-java-format" />
+    <plugin id="google-java-format" min-version="1.12.0.0"/>
   </component>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -421,6 +421,13 @@
               </sortPom>
             </pom>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>com.google.googlejavaformat</groupId>
+              <artifactId>google-java-format</artifactId>
+              <version>${plugin.version.googlejavaformat}</version>
+            </dependency>
+          </dependencies>
           <executions>
             <execution>
               <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -78,11 +78,14 @@
     <nexus.release.repository.id>camunda-nexus</nexus.release.repository.id>
     <nexus.snapshot.repository>https://app.camunda.com/nexus/content/repositories/zeebe-io-snapshots</nexus.snapshot.repository>
     <nexus.snapshot.repository.id>camunda-nexus</nexus.snapshot.repository.id>
-    <plugin.version.dependency>3.3.0</plugin.version.dependency>
 
+    <plugin.version.dependency>3.3.0</plugin.version.dependency>
     <plugin.version.flatten>1.2.7</plugin.version.flatten>
     <plugin.version.fmt>2.9.1</plugin.version.fmt>
+
+    <!-- when updating this version, also change it in .idea/externalDependencies.xml -->
     <plugin.version.googlejavaformat>1.12.0</plugin.version.googlejavaformat>
+
     <plugin.version.jacoco>0.8.7</plugin.version.jacoco>
     <plugin.version.javadoc>3.3.2</plugin.version.javadoc>
     <plugin.version.license>4.1</plugin.version.license>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Dependabot does not control the version of the google-java-format plugin used by spotless. By adding an explicit maven dependency on the plugin we can make Dependabot control it.

Note that adding this dependency doesn't change anything to the rest of the project. It also doesn't really interfere with this specific plugin, as it would in the worst case, simply add the same classes twice on the classpath. By using a property, we can control that the dependent version is the same as the one loaded inside spotless.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #277 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
