### PR TITLE
Run testcontainer tests with java 8

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/setup-java@v3.1.0
         with:
           distribution: temurin
-          java-version: 17 # Change to java 8 when tests are properly separated (https://github.com/camunda/zeebe-process-test/issues/195)
+          java-version: 17
           cache: maven
 
       - name: Package
@@ -96,9 +96,19 @@ jobs:
           IMAGE_NAME_KEY: container.image.name
           IMAGE_TAG_KEY: container.image.tag
 
+      - name: Downgrade Java environment
+        uses: actions/setup-java@v3.0.0
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: maven
+
+      # Deleting .mvn/jvm.config is a workaround for JDK8, which does not support the --add-exports options
       - name: Build
         id: build
-        run: mvn -B -U -P testcontainer "-Dsurefire.rerunFailingTestsCount=5" install
+        run: |
+          rm .mvn/jvm.config
+          mvn -B -U -pl :zeebe-process-test-qa -am -P testcontainer "-Dsurefire.rerunFailingTestsCount=5" install -DskipChecks
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v2

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,8 @@
     <plugin.version.spotless>2.22.0</plugin.version.spotless>
     <plugin.version.surefire>3.0.0-M6</plugin.version.surefire>
 
+    <skipChecks>false</skipChecks>
+
     <version.grpc>1.45.1</version.grpc>
     <version.java>17</version.java>
     <version.protobuf>3.19.4</version.protobuf>
@@ -425,6 +427,8 @@
                 <sortProperties>true</sortProperties>
               </sortPom>
             </pom>
+            <applySkip>${skipChecks}</applySkip>
+            <checkSkip>${skipChecks}</checkSkip>
           </configuration>
           <dependencies>
             <dependency>
@@ -516,6 +520,7 @@
             </goals>
             <configuration>
               <failOnWarning>true</failOnWarning>
+              <skip>${skipChecks}</skip>
             </configuration>
           </execution>
         </executions>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -22,18 +22,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-process-test-extension</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-process-test-extension-testcontainer</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
@@ -124,7 +112,38 @@
 
   <profiles>
     <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.camunda</groupId>
+          <artifactId>zeebe-process-test-extension</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.camunda</groupId>
+          <artifactId>zeebe-process-test-extension-testcontainer</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
       <id>embedded</id>
+      <dependencies>
+        <dependency>
+          <groupId>io.camunda</groupId>
+          <artifactId>zeebe-process-test-extension</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.camunda</groupId>
+          <artifactId>zeebe-process-test-extension-testcontainer</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
       <build>
         <plugins>
           <plugin>
@@ -143,16 +162,23 @@
 
     <profile>
       <id>testcontainer</id>
+      <dependencies>
+        <dependency>
+          <groupId>io.camunda</groupId>
+          <artifactId>zeebe-process-test-extension-testcontainer</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>${plugin.version.surefire}</version>
+            <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
-              <excludes>
-                <exclude>**/embedded/**/*.java</exclude>
-              </excludes>
+              <testExcludes>
+                <testExclude>**/embedded/**/*.java</testExclude>
+                <testExclude>**/ExtendAbstractsTest.java</testExclude>
+              </testExcludes>
             </configuration>
           </plugin>
         </plugins>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -16,6 +16,10 @@
 
   <description>QA tests for testing the Zeebe Process Test project.</description>
 
+  <properties>
+    <version.java>8</version.java>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.camunda</groupId>

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/abstracts/examples/AbstractPrCreatedTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/abstracts/examples/AbstractPrCreatedTest.java
@@ -37,7 +37,7 @@ import io.camunda.zeebe.client.api.response.PublishMessageResponse;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.qa.util.Utilities;
 import java.time.Duration;
-import java.util.Map;
+import java.util.Collections;
 import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,12 +73,17 @@ public abstract class AbstractPrCreatedTest {
     // Given
     final String prId = "123";
     final PublishMessageResponse prCreatedResponse =
-        Utilities.sendMessage(engine, client, PR_CREATED_MSG, "", Map.of(PR_ID_VAR, prId));
+        Utilities.sendMessage(
+            engine, client, PR_CREATED_MSG, "", Collections.singletonMap(PR_ID_VAR, prId));
 
     // When
     completeTask(REQUEST_REVIEW);
     Utilities.sendMessage(
-        engine, client, REVIEW_RECEIVED_MSG, prId, Map.of(REVIEW_RESULT_VAR, "approved"));
+        engine,
+        client,
+        REVIEW_RECEIVED_MSG,
+        prId,
+        Collections.singletonMap(REVIEW_RESULT_VAR, "approved"));
     completeTask(AUTOMATED_TESTS_RUN_TESTS);
     completeTask(AUTOMATED_TESTS_RUN_TESTS);
     completeTask(AUTOMATED_TESTS_RUN_TESTS);
@@ -103,7 +108,8 @@ public abstract class AbstractPrCreatedTest {
     // Given
     final String prId = "123";
     final PublishMessageResponse prCreatedResponse =
-        Utilities.sendMessage(engine, client, PR_CREATED_MSG, "", Map.of(PR_ID_VAR, prId));
+        Utilities.sendMessage(
+            engine, client, PR_CREATED_MSG, "", Collections.singletonMap(PR_ID_VAR, prId));
 
     // When
     completeTask(REQUEST_REVIEW);
@@ -113,7 +119,11 @@ public abstract class AbstractPrCreatedTest {
     Utilities.increaseTime(engine, Duration.ofDays(1));
     completeTask(REMIND_REVIEWER);
     Utilities.sendMessage(
-        engine, client, REVIEW_RECEIVED_MSG, prId, Map.of(REVIEW_RESULT_VAR, "approved"));
+        engine,
+        client,
+        REVIEW_RECEIVED_MSG,
+        prId,
+        Collections.singletonMap(REVIEW_RESULT_VAR, "approved"));
     completeTask(MERGE_CODE);
     completeTask(DEPLOY_SNAPSHOT);
 
@@ -131,7 +141,8 @@ public abstract class AbstractPrCreatedTest {
     // Given
     final String prId = "123";
     final PublishMessageResponse prCreatedResponse =
-        Utilities.sendMessage(engine, client, PR_CREATED_MSG, "", Map.of(PR_ID_VAR, prId));
+        Utilities.sendMessage(
+            engine, client, PR_CREATED_MSG, "", Collections.singletonMap(PR_ID_VAR, prId));
 
     // When
     completeTask(REQUEST_REVIEW);
@@ -139,11 +150,19 @@ public abstract class AbstractPrCreatedTest {
     completeTask(AUTOMATED_TESTS_RUN_TESTS);
     completeTask(AUTOMATED_TESTS_RUN_TESTS);
     Utilities.sendMessage(
-        engine, client, REVIEW_RECEIVED_MSG, prId, Map.of(REVIEW_RESULT_VAR, "rejected"));
+        engine,
+        client,
+        REVIEW_RECEIVED_MSG,
+        prId,
+        Collections.singletonMap(REVIEW_RESULT_VAR, "rejected"));
     completeTask(MAKE_CHANGES);
     completeTask(REQUEST_REVIEW);
     Utilities.sendMessage(
-        engine, client, REVIEW_RECEIVED_MSG, prId, Map.of(REVIEW_RESULT_VAR, "approved"));
+        engine,
+        client,
+        REVIEW_RECEIVED_MSG,
+        prId,
+        Collections.singletonMap(REVIEW_RESULT_VAR, "approved"));
     completeTask(MERGE_CODE);
     completeTask(DEPLOY_SNAPSHOT);
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
We claim to have the guarantee that the `zeebe-process-test-extension-testcontainer` is java 8 compatible. We are guaranteeing this by setting the java version in the maven configuration. However, we do not test this in our CI. The testcontainer tests we have are still being run with java 17.

This PR changes this. By using maven profiles to manage dependencies and plugins we can compile and run the testcontainer tests using java 8. With this we can test if our guarantee holds any truth.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #287

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
