### PR TITLE
NPE during logging

### DIFF
--- a/filters/pom.xml
+++ b/filters/pom.xml
@@ -55,6 +55,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -266,20 +266,13 @@ public class RecordStreamLogger {
     return joiner.toString();
   }
 
-  private String logVariables(final Map<String, Object> variables) {
+  protected String logVariables(final Map<String, Object> variables) {
     if (variables.isEmpty()) {
       return "";
     }
 
     final StringJoiner joiner = new StringJoiner(", ", "[", "]");
-    variables.forEach(
-        (key, value) -> {
-          if (value != null) {
-            joiner.add(key + " -> " + value);
-          } else {
-            joiner.add(key + " -> null");
-          }
-        });
+    variables.forEach((key, value) -> joiner.add(key + " -> " + value));
     return String.format("(Variables: %s)", joiner);
   }
 

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractProcessInstanceAssertTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractProcessInstanceAssertTest.java
@@ -50,6 +50,7 @@ public abstract class AbstractProcessInstanceAssertTest {
     TYPED_TEST_VARIABLES.put("numberProperty", 123);
     TYPED_TEST_VARIABLES.put("booleanProperty", true);
     TYPED_TEST_VARIABLES.put("complexProperty", Arrays.asList("Element 1", "Element 2"));
+    TYPED_TEST_VARIABLES.put("nullProperty", null);
   }
 
   // These tests are for testing assertions as well as examples for users


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Variable with a null value produce NPE when logging the record stream. This PR adds a null check and a bunch of tests for our logger to prevent this in the future.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #305 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
