### PR TITLE
Testcontainer engine lifecycle

### DIFF
--- a/engine-agent/src/main/java/io/camunda/zeebe/process/test/engine/agent/EngineControlImpl.java
+++ b/engine-agent/src/main/java/io/camunda/zeebe/process/test/engine/agent/EngineControlImpl.java
@@ -29,12 +29,8 @@ import io.grpc.stub.StreamObserver;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class EngineControlImpl extends EngineControlImplBase {
-
-  private static final Logger LOG = LoggerFactory.getLogger(EngineControlImpl.class);
 
   private ZeebeTestEngine engine;
   private RecordStreamSourceWrapper recordStreamSource;
@@ -49,6 +45,7 @@ public final class EngineControlImpl extends EngineControlImplBase {
       final StartEngineRequest request,
       final StreamObserver<StartEngineResponse> responseObserver) {
     engine.start();
+    recordStreamSource = new RecordStreamSourceWrapper(engine.getRecordStreamSource());
 
     final StartEngineResponse response = StartEngineResponse.newBuilder().build();
     responseObserver.onNext(response);
@@ -71,8 +68,6 @@ public final class EngineControlImpl extends EngineControlImplBase {
       final StreamObserver<ResetEngineResponse> responseObserver) {
     engine.stop();
     engine = EngineFactory.create(AgentProperties.getGatewayPort());
-    recordStreamSource = new RecordStreamSourceWrapper(engine.getRecordStreamSource());
-    engine.start();
 
     final ResetEngineResponse response = ResetEngineResponse.newBuilder().build();
     responseObserver.onNext(response);

--- a/engine-agent/src/main/java/io/camunda/zeebe/process/test/engine/agent/ZeebeProcessTestEngine.java
+++ b/engine-agent/src/main/java/io/camunda/zeebe/process/test/engine/agent/ZeebeProcessTestEngine.java
@@ -12,8 +12,12 @@ import io.camunda.zeebe.process.test.engine.EngineFactory;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ZeebeProcessTestEngine {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ZeebeProcessTestEngine.class);
 
   public static void main(final String[] args) throws IOException {
     final ZeebeTestEngine engine = EngineFactory.create(AgentProperties.getGatewayPort());
@@ -24,5 +28,9 @@ public class ZeebeProcessTestEngine {
             .build();
 
     server.start();
+
+    // In the testcontainer extension we are waiting for this line to be logged before continuing
+    // test execution. If this log gets changed please also change the extension!
+    LOG.info("ZeebeProcessTestEngine container has started ...");
   }
 }

--- a/engine-agent/src/main/java/io/camunda/zeebe/process/test/engine/agent/ZeebeProcessTestEngine.java
+++ b/engine-agent/src/main/java/io/camunda/zeebe/process/test/engine/agent/ZeebeProcessTestEngine.java
@@ -23,7 +23,6 @@ public class ZeebeProcessTestEngine {
             .addService(engineService)
             .build();
 
-    engine.start();
     server.start();
   }
 }

--- a/engine-protocol/src/main/proto/engine_control.proto
+++ b/engine-protocol/src/main/proto/engine_control.proto
@@ -65,6 +65,8 @@ service EngineControl {
     Using this while running tests concurrently will still cause issues. This is
     because the first test will be using the engine, whilst the second test will
     reset it. Therefore, the data from the first test will get lost.
+
+    After resetting the engine still needs to be started.
    */
   rpc ResetEngine (ResetEngineRequest) returns (ResetEngineResponse);
 

--- a/extension-testcontainer/src/main/java/io.camunda.zeebe.process.test.extension.testcontainer/EngineContainer.java
+++ b/extension-testcontainer/src/main/java/io.camunda.zeebe.process.test.extension.testcontainer/EngineContainer.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 /** Singleton object which manages access to the testcontainer that's running the test engine */
@@ -49,6 +50,7 @@ public final class EngineContainer extends GenericContainer<EngineContainer> {
         new EngineContainer(ContainerProperties.getDockerImageName())
             .withExposedPorts(
                 ContainerProperties.getContainerPort(), ContainerProperties.getGatewayPort())
-            .withLogConsumer(new Slf4jLogConsumer(LOG));
+            .withLogConsumer(new Slf4jLogConsumer(LOG))
+            .waitingFor(Wait.forLogMessage(".*ZeebeProcessTestEngine container has started.*", 1));
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The start of the engine was tied to the start of testcontainer. This resulted in the following lifecycle:
1. BeforeAll - start the testcontainer and the engine
2. BeforeEach - stop the engine, recreate it and start it (reset)

This causes some strange behaviour. Upon test start we are starting the engine and resetting it without using it. With this change the lifecycle becomes somewhat more natural:
1. BeforeAll - start the testcontainer
2. BeforeEach - start the engine
3. AfterEach - stop the engine and recreate it (new reset)

This new lifecycle also matches more closely with the embedded lifecycle where we do:
1. BeforeEach - create and start the engine
2. AfterEach - stop the engine

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #304 
related to https://github.com/camunda-community-hub/spring-zeebe/issues/189

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [x] Javadoc has been written
* [ ] The documentation is updated
