### PR TITLE
Support sequence flow in hasPassedElement assertions

### DIFF
--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/ProcessInstanceAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/ProcessInstanceAssert.java
@@ -214,7 +214,8 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
             .withProcessInstanceKey(actual)
             .withRejectionType(RejectionType.NULL_VAL)
             .withElementId(elementId)
-            .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED)
+            .withIntents(
+                ProcessInstanceIntent.ELEMENT_COMPLETED, ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
             .stream()
             .count();
 
@@ -239,7 +240,8 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
             .withProcessInstanceKey(actual)
             .withRejectionType(RejectionType.NULL_VAL)
             .withElementIdIn(elementIds)
-            .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED)
+            .withIntents(
+                ProcessInstanceIntent.ELEMENT_COMPLETED, ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
             .stream()
             .map(Record::getValue)
             .map(ProcessInstanceRecordValue::getElementId)

--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/ProcessInstanceRecordStreamFilter.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/ProcessInstanceRecordStreamFilter.java
@@ -61,6 +61,12 @@ public class ProcessInstanceRecordStreamFilter {
         stream.filter(record -> record.getIntent() == intent));
   }
 
+  public ProcessInstanceRecordStreamFilter withIntents(final ProcessInstanceIntent... intents) {
+    return new ProcessInstanceRecordStreamFilter(
+        stream.filter(
+            record -> Arrays.stream(intents).anyMatch(intent -> record.getIntent() == intent)));
+  }
+
   public ProcessInstanceRecordStreamFilter withElementId(final String elementId) {
     return new ProcessInstanceRecordStreamFilter(
         stream.filter(record -> record.getValue().getElementId().equals(elementId)));

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractProcessInstanceAssertTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractProcessInstanceAssertTest.java
@@ -214,6 +214,8 @@ public abstract class AbstractProcessInstanceAssertTest {
       // then
       BpmnAssert.assertThat(instanceEvent)
           .hasPassedElement(ProcessPackLoopingServiceTask.ELEMENT_ID, totalLoops);
+      BpmnAssert.assertThat(instanceEvent)
+          .hasPassedElement(ProcessPackLoopingServiceTask.LOOP_SEQUENCE_FLOW_ID, totalLoops - 1);
     }
 
     @Test
@@ -222,12 +224,13 @@ public abstract class AbstractProcessInstanceAssertTest {
       // given
       Utilities.deployResource(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
-          Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
+          Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 2);
       final ProcessInstanceEvent instanceEvent =
           Utilities.startProcessInstance(
               engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // when
+      Utilities.completeTask(engine, client, ProcessPackLoopingServiceTask.ELEMENT_ID);
       Utilities.completeTask(engine, client, ProcessPackLoopingServiceTask.ELEMENT_ID);
 
       // then
@@ -235,6 +238,10 @@ public abstract class AbstractProcessInstanceAssertTest {
           .hasPassedElementsInOrder(
               ProcessPackLoopingServiceTask.START_EVENT_ID,
               ProcessPackLoopingServiceTask.ELEMENT_ID,
+              ProcessPackLoopingServiceTask.GATEWAY_ELEMENT_ID,
+              ProcessPackLoopingServiceTask.LOOP_SEQUENCE_FLOW_ID,
+              ProcessPackLoopingServiceTask.ELEMENT_ID,
+              ProcessPackLoopingServiceTask.GATEWAY_ELEMENT_ID,
               ProcessPackLoopingServiceTask.END_EVENT_ID);
     }
 

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/util/Utilities.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/util/Utilities.java
@@ -221,6 +221,7 @@ public class Utilities {
     public static final String TOTAL_LOOPS =
         "totalLoops"; // variable name to indicate number of loops
     public static final String GATEWAY_ELEMENT_ID = "Gateway_0fhwf5d";
+    public static final String LOOP_SEQUENCE_FLOW_ID = "loopSequenceFlow";
     public static final String START_EVENT_ID = "startevent";
     public static final String END_EVENT_ID = "endevent";
   }

--- a/qa/abstracts/src/main/resources/looping-servicetask.bpmn
+++ b/qa/abstracts/src/main/resources/looping-servicetask.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0vjlomv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0vjlomv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0-alpha.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
   <bpmn:process id="looping-servicetask" name="looping servicetask" isExecutable="true">
     <bpmn:startEvent id="startevent" name="Start event">
       <bpmn:extensionElements>
@@ -22,22 +22,22 @@
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0gk7cr0</bpmn:incoming>
-      <bpmn:incoming>Flow_0wjr3ms</bpmn:incoming>
+      <bpmn:incoming>loopSequenceFlow</bpmn:incoming>
       <bpmn:outgoing>Flow_0cw7eu9</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:exclusiveGateway id="Gateway_0fhwf5d" default="Flow_117ogjm">
       <bpmn:incoming>Flow_0cw7eu9</bpmn:incoming>
       <bpmn:outgoing>Flow_117ogjm</bpmn:outgoing>
-      <bpmn:outgoing>Flow_0wjr3ms</bpmn:outgoing>
+      <bpmn:outgoing>loopSequenceFlow</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_117ogjm" sourceRef="Gateway_0fhwf5d" targetRef="endevent" />
-    <bpmn:sequenceFlow id="Flow_0wjr3ms" sourceRef="Gateway_0fhwf5d" targetRef="servicetask">
+    <bpmn:sequenceFlow id="loopSequenceFlow" sourceRef="Gateway_0fhwf5d" targetRef="servicetask">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">= loopAmount != totalLoops</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="looping-servicetask">
-      <bpmndi:BPMNEdge id="Flow_0wjr3ms_di" bpmnElement="Flow_0wjr3ms">
+      <bpmndi:BPMNEdge id="Flow_0wjr3ms_di" bpmnElement="loopSequenceFlow">
         <di:waypoint x="410" y="142" />
         <di:waypoint x="410" y="80" />
         <di:waypoint x="300" y="80" />


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Sequence flows will never have an event with an ELEMENT_COMPLETED intent. Instead they get a single event with a SEQUENCE_FLOW_TAKEN intent. Because of this we would always filter out any sequence flows in the assertion, making it impossible to assert that a specific flow has been passed. By adding the SEQUENCE_FLOW_TAKEN intent we include sequence flows in our lists and allow asserting whether or not they have been passed.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #318 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
