### PR TITLE
Don't run revapi against pre releases

### DIFF
--- a/engine-protocol/src/main/proto/proto.lock
+++ b/engine-protocol/src/main/proto/proto.lock
@@ -1,0 +1,137 @@
+{
+  "definitions": [
+    {
+      "protopath": "engine_control.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "StartEngineRequest"
+          },
+          {
+            "name": "StartEngineResponse"
+          },
+          {
+            "name": "StopEngineRequest"
+          },
+          {
+            "name": "StopEngineResponse"
+          },
+          {
+            "name": "ResetEngineRequest"
+          },
+          {
+            "name": "ResetEngineResponse"
+          },
+          {
+            "name": "IncreaseTimeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "milliseconds",
+                "type": "int32"
+              }
+            ]
+          },
+          {
+            "name": "IncreaseTimeResponse"
+          },
+          {
+            "name": "WaitForIdleStateRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "timeout",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "WaitForIdleStateResponse"
+          },
+          {
+            "name": "WaitForBusyStateRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "timeout",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "WaitForBusyStateResponse"
+          },
+          {
+            "name": "GetRecordsRequest"
+          },
+          {
+            "name": "RecordResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "recordJson",
+                "type": "string"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "EngineControl",
+            "rpcs": [
+              {
+                "name": "StartEngine",
+                "in_type": "StartEngineRequest",
+                "out_type": "StartEngineResponse"
+              },
+              {
+                "name": "StopEngine",
+                "in_type": "StopEngineRequest",
+                "out_type": "StopEngineResponse"
+              },
+              {
+                "name": "ResetEngine",
+                "in_type": "ResetEngineRequest",
+                "out_type": "ResetEngineResponse"
+              },
+              {
+                "name": "IncreaseTime",
+                "in_type": "IncreaseTimeRequest",
+                "out_type": "IncreaseTimeResponse"
+              },
+              {
+                "name": "WaitForIdleState",
+                "in_type": "WaitForIdleStateRequest",
+                "out_type": "WaitForIdleStateResponse"
+              },
+              {
+                "name": "WaitForBusyState",
+                "in_type": "WaitForBusyStateRequest",
+                "out_type": "WaitForBusyStateResponse"
+              },
+              {
+                "name": "GetRecords",
+                "in_type": "GetRecordsRequest",
+                "out_type": "RecordResponse",
+                "out_streamed": true
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "engine_protocol"
+        },
+        "options": [
+          {
+            "name": "java_multiple_files",
+            "value": "false"
+          },
+          {
+            "name": "java_package",
+            "value": "io.camunda.zeebe.process.test.engine.protocol"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -464,6 +464,8 @@
               </configurationFile>
             </analysisConfigurationFiles>
             <oldVersion>LATEST</oldVersion>
+            <!-- Don't check compatibility against pre-releases -->
+            <versionFormat>^\d+\.\d+\.\d+$</versionFormat>
           </configuration>
           <dependencies>
             <dependency>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR adds a version format to the revapi configuration. This is a regex that will make sure we only check backwards compatibility against patch, minor and major releases.

I've also checked in the `proto.lock` file. This file is used to check the backwards compatibility of our grpc api.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #283 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
