### PR TITLE
build: set zeebe version to 8.1.0-alpha1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,13 @@
         <version>${dependency.zeebe.version}</version>
       </dependency>
 
+      <!-- Specify the version to avoid dependency convergence error due to https://github.com/camunda/zeebe/issues/9280 -->
+      <dependency>
+        <groupId>org.camunda.bpm.model</groupId>
+        <artifactId>camunda-dmn-model</artifactId>
+        <version>7.17.0</version>
+      </dependency>
+
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-logstreams</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <dependency.snakeyaml.version>1.30</dependency.snakeyaml.version>
     <dependency.spring.version>5.3.19</dependency.spring.version>
     <dependency.testcontainers.version>1.17.1</dependency.testcontainers.version>
-    <dependency.zeebe.version>8.0.2</dependency.zeebe.version>
+    <dependency.zeebe.version>8.1.0-alpha1</dependency.zeebe.version>
 
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
 


### PR DESCRIPTION
## Description

Set zeebe version to 8.1.0-alpha1 as part of the zeebe release process
