### PR TITLE
Disabling environment variable override for ZeebeClient in test 

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryEngine.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryEngine.java
@@ -95,6 +95,7 @@ class InMemoryEngine implements ZeebeTestEngine {
   @Override
   public ZeebeClient createClient() {
     return ZeebeClient.newClientBuilder()
+        .applyEnvironmentVariableOverrides(false)
         .gatewayAddress(getGatewayAddress())
         .usePlaintext()
         .build();

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
@@ -111,6 +111,7 @@ class EngineClientTest {
     // given
     final ZeebeClient client =
         ZeebeClient.newClientBuilder()
+            .applyEnvironmentVariableOverrides(false)
             .usePlaintext()
             .gatewayAddress(zeebeEngine.getGatewayAddress())
             .build();

--- a/extension-testcontainer/src/main/java/io.camunda.zeebe.process.test.extension.testcontainer/ContainerizedEngine.java
+++ b/extension-testcontainer/src/main/java/io.camunda.zeebe.process.test.extension.testcontainer/ContainerizedEngine.java
@@ -94,6 +94,7 @@ public class ContainerizedEngine implements ZeebeTestEngine {
   @Override
   public ZeebeClient createClient() {
     return ZeebeClient.newClientBuilder()
+        .applyEnvironmentVariableOverrides(false)
         .gatewayAddress(getGatewayAddress())
         .usePlaintext()
         .build();

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <dependency.snakeyaml.version>1.30</dependency.snakeyaml.version>
     <dependency.spring.version>5.3.20</dependency.spring.version>
     <dependency.testcontainers.version>1.17.1</dependency.testcontainers.version>
-    <dependency.zeebe.version>8.1.0-alpha1</dependency.zeebe.version>
+    <dependency.zeebe.version>8.1.0-SNAPSHOT</dependency.zeebe.version>
 
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
 


### PR DESCRIPTION
See #375 

This PR can only be merged with the latest 8.1.0-SNAPSHOT as of today which seems to bring other changes that need to be adjusted first. I prep it anyway and ask to merge (or reimplement) this before releasing the next version (please :-)). Thx!