### PR TITLE
350 lenient value comparison

### DIFF
--- a/assertions/pom.xml
+++ b/assertions/pom.xml
@@ -29,11 +29,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-test-util</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>zeebe-process-test-filters</artifactId>
     </dependency>
 
@@ -45,6 +40,16 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-client-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
 
     <!-- Test scope-->

--- a/assertions/pom.xml
+++ b/assertions/pom.xml
@@ -29,6 +29,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-test-util</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-process-test-filters</artifactId>
     </dependency>
 

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/VariablesMapAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/VariablesMapAssert.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2021 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.camunda.zeebe.process.test.assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import io.camunda.zeebe.test.util.JsonUtil;
+import java.util.Map;
+import org.assertj.core.api.AbstractAssert;
+
+/**
+ * Assertion for variable maps {@code Map<String, String>} which contain JSON strings as values
+ * (e.g. variables in process instances, messages, job activations)
+ */
+public class VariablesMapAssert extends AbstractAssert<VariablesMapAssert, Map<String, String>> {
+
+  private static final ZeebeObjectMapper OBJECT_MAPPER = new ZeebeObjectMapper();
+
+  public VariablesMapAssert(final Map<String, String> actual) {
+    super(actual, VariablesMapAssert.class);
+  }
+
+  /**
+   * Assert that the given variable name is a key in the given map of variables. *
+   *
+   * @param name The name of the variable
+   * @return this ${@link ProcessInstanceAssert}
+   */
+  public VariablesMapAssert containsVariable(final String name) {
+    assertThat(actual)
+        .withFailMessage(
+            "Unable to find variable with name `%s`. Available variables are: %s",
+            name, actual.keySet())
+        .containsKey(name);
+    return this;
+  }
+
+  public VariablesMapAssert hasVariableWithValue(final String name, final Object value) {
+    final String expectedValue = OBJECT_MAPPER.toJson(value);
+    final String actualValue = actual.get(name);
+
+    containsVariable(name);
+
+    try {
+      JsonUtil.assertEquality(expectedValue, actualValue);
+    } catch (final AssertionError e) {
+      fail(
+          "The variable '%s' does not have the expected value. The value passed in"
+              + " ('%s') is internally mapped to a JSON String that yields '%s'. However, the "
+              + "actual value (as JSON String) is '%s'.",
+          name, value, expectedValue, actualValue);
+    }
+
+    return this;
+  }
+}

--- a/assertions/src/test/java/io/camunda/zeebe/process/test/assertions/VariablesMapAssertTest.java
+++ b/assertions/src/test/java/io/camunda/zeebe/process/test/assertions/VariablesMapAssertTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2021 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.camunda.zeebe.process.test.assertions;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class VariablesMapAssertTest {
+
+  private static final String KEY = "key";
+  private static final String UNKNOWN_KEY = "unknownKey";
+
+  private static final Map<String, String> VARIABLES = new HashMap<>();
+
+  static {
+    VARIABLES.put(KEY, "\"value\"");
+  }
+
+  @Nested
+  class ContainsVariable {
+
+    @Test
+    void shouldNotThrowAssertionErrorWhenVariableIsKnown() {
+      // given
+      final VariablesMapAssert sut = new VariablesMapAssert(VARIABLES);
+
+      // when + then
+      assertThatNoException().isThrownBy(() -> sut.containsVariable(KEY));
+    }
+
+    @Test
+    void shouldThrowAssertionErrorWhenVariableIsUnknown() {
+      // given
+      final VariablesMapAssert sut = new VariablesMapAssert(VARIABLES);
+
+      // when + then
+      assertThatThrownBy(() -> sut.containsVariable(UNKNOWN_KEY))
+          .isExactlyInstanceOf(AssertionError.class)
+          .hasMessage(
+              "Unable to find variable with name `%s`. Available variables are: %s",
+              UNKNOWN_KEY, VARIABLES.keySet());
+    }
+  }
+
+  @Nested
+  class HasVariableWithValue {
+
+    @Test
+    void shouldNotThrowAssertionErrorWhenVariableIsKnownAndValueIsCorrect() {
+      // given
+      final VariablesMapAssert sut = new VariablesMapAssert(VARIABLES);
+
+      // when + then
+      assertThatNoException().isThrownBy(() -> sut.hasVariableWithValue(KEY, "value"));
+    }
+
+    @Test
+    void shouldThrowAssertionErrorWhenVariableIsUnknown() {
+      // given
+      final VariablesMapAssert sut = new VariablesMapAssert(VARIABLES);
+
+      // when + then
+      assertThatThrownBy(() -> sut.hasVariableWithValue(UNKNOWN_KEY, null))
+          .isExactlyInstanceOf(AssertionError.class)
+          .hasMessage(
+              "Unable to find variable with name `%s`. Available variables are: %s",
+              UNKNOWN_KEY, VARIABLES.keySet());
+    }
+
+    @Test
+    void shouldThrowAssertionErrorWhenValueIsDifferent() {
+      // given
+      final VariablesMapAssert sut = new VariablesMapAssert(VARIABLES);
+
+      // when + then
+      assertThatThrownBy(() -> sut.hasVariableWithValue(KEY, "someOtherValue"))
+          .isExactlyInstanceOf(AssertionError.class)
+          .hasMessage(
+              "The variable 'key' does not have the expected value. The value passed in ('someOtherValue') is internally mapped to a JSON String that yields '\"someOtherValue\"'. However, the actual value (as JSON String) is '\"value\"'.");
+    }
+
+    /**
+     * Verifies that the logic to compare the actual and expected value is lenient with respect to
+     * the order of fields in a JSON object
+     */
+    @Test
+    void shouldBeLenientWithRespectToFieldOrder() {
+      // given
+      final Map<String, Boolean> value = new HashMap<>();
+      value.put("a", true);
+      value.put("b", false);
+
+      final String jsonRepresentation1 = "{ \"a\" : true, \"b\": false }";
+      final String jsonRepresentation2 = "{ \"b\" : false, \"a\": true }";
+
+      final Map<String, String> map1 = new HashMap<>();
+      map1.put(KEY, jsonRepresentation1);
+
+      final Map<String, String> map2 = new HashMap<>();
+      map2.put(KEY, jsonRepresentation2);
+
+      final VariablesMapAssert sut1 = new VariablesMapAssert(map1);
+      final VariablesMapAssert sut2 = new VariablesMapAssert(map2);
+
+      // when + then
+      assertThatNoException().isThrownBy(() -> sut1.hasVariableWithValue(KEY, value));
+      assertThatNoException().isThrownBy(() -> sut2.hasVariableWithValue(KEY, value));
+    }
+  }
+}

--- a/assertions/src/test/java/io/camunda/zeebe/process/test/assertions/VariablesMapAssertTest.java
+++ b/assertions/src/test/java/io/camunda/zeebe/process/test/assertions/VariablesMapAssertTest.java
@@ -93,7 +93,7 @@ class VariablesMapAssertTest {
 
       // when + then
       assertThatThrownBy(() -> sut.hasVariableWithValue(KEY, "someOtherValue"))
-          .isExactlyInstanceOf(AssertionError.class)
+          .isInstanceOf(AssertionError.class)
           .hasMessage(
               "The variable 'key' does not have the expected value. The value passed in ('someOtherValue') is internally mapped to a JSON String that yields '\"someOtherValue\"'. However, the actual value (as JSON String) is '\"value\"'.");
     }

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractProcessInstanceAssertTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractProcessInstanceAssertTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.process.test.qa.abstracts.assertions;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -36,7 +37,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import org.assertj.core.api.Assertions;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -408,12 +408,12 @@ public abstract class AbstractProcessInstanceAssertTest {
               engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, TYPED_TEST_VARIABLES);
 
       // then
-      final SoftAssertions softly = new SoftAssertions();
-
-      TYPED_TEST_VARIABLES.forEach(
-          (key, value) -> BpmnAssert.assertThat(instanceEvent).hasVariableWithValue(key, value));
-
-      softly.assertAll();
+      assertThatNoException()
+          .isThrownBy(
+              () ->
+                  TYPED_TEST_VARIABLES.forEach(
+                      (key, value) ->
+                          BpmnAssert.assertThat(instanceEvent).hasVariableWithValue(key, value)));
     }
 
     @Test
@@ -998,8 +998,8 @@ public abstract class AbstractProcessInstanceAssertTest {
       assertThatThrownBy(() -> BpmnAssert.assertThat(instanceEvent).hasVariable(expectedVariable))
           .isInstanceOf(AssertionError.class)
           .hasMessage(
-              "Process with key %s does not contain variable with name `%s`. Available variables are: [%s]",
-              instanceEvent.getProcessInstanceKey(), expectedVariable, actualVariable);
+              "Unable to find variable with name `%s`. Available variables are: [%s]",
+              expectedVariable, actualVariable);
     }
 
     @Test


### PR DESCRIPTION
## Description
* refactoring to extract the logic to assert against variables into its own class. This way, the logic can later be reused for process, job and message variables
* slight modification of error messages as a result of this refactoring
* changed comparison logic to be lenient regarding field order in JSON objects
* added test for new assert class

## Related issues

closes #350

<!-- Cut-off marker
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [X] If it fixes a bug then PRs are created to backport the fix

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [X] Javadoc has been written
* [ ] The documentation is updated
