### PR TITLE
chore: use ephemeral free port

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
@@ -26,12 +26,24 @@ import io.camunda.zeebe.util.sched.clock.ActorClock;
 import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.util.concurrent.CompletableFuture;
 
 public class EngineFactory {
 
   public static ZeebeTestEngine create() {
-    return create(26499);
+    return create(findFreePort());
+  }
+
+  private static int findFreePort() {
+    final int freePort;
+    try (final var serverSocket = new ServerSocket(0)) {
+      freePort = serverSocket.getLocalPort();
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+    return freePort;
   }
 
   public static ZeebeTestEngine create(final int port) {


### PR DESCRIPTION
## Description

Now uses a free ephemeral port by default

## Related issues

closes #366 

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
