### PR TITLE
Build docker image with Maven

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Build
         id: build
-        run: mvn -B -U -pl "-:zeebe-process-test-qa-testcontainers" "-Dsurefire.rerunFailingTestsCount=5" clean install
+        run: mvn -B -U -pl "-:zeebe-process-test-qa-testcontainers" -P \!localBuild "-Dsurefire.rerunFailingTestsCount=5" clean install
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v3
@@ -79,7 +79,7 @@ jobs:
           cache: maven
 
       - name: Package
-        run: mvn -B -U clean package -DskipTests
+        run: mvn -B -U -P \!localBuild clean package -DskipTests
 
       - name: Build engine docker container
         run: |
@@ -108,7 +108,7 @@ jobs:
         id: build
         run: |
           rm .mvn/jvm.config
-          mvn -B -U -pl ":zeebe-process-test-qa-testcontainers" -am "-Dsurefire.rerunFailingTestsCount=5" install -DskipChecks
+          mvn -B -U -pl ":zeebe-process-test-qa-testcontainers" -P \!localBuild -am "-Dsurefire.rerunFailingTestsCount=5" install -DskipChecks
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Build
         id: build
-        run: mvn -B -U -pl "-:zeebe-process-test-qa-testcontainers" -P \!localBuild "-Dsurefire.rerunFailingTestsCount=5" clean install
+        run: mvn -B -U -pl "-:zeebe-process-test-qa-testcontainers" -P !localBuild "-Dsurefire.rerunFailingTestsCount=5" clean install
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v3
@@ -79,7 +79,7 @@ jobs:
           cache: maven
 
       - name: Package
-        run: mvn -B -U -P \!localBuild clean package -DskipTests
+        run: mvn -B -U -P !localBuild clean package -DskipTests
 
       - name: Build engine docker container
         run: |
@@ -108,7 +108,7 @@ jobs:
         id: build
         run: |
           rm .mvn/jvm.config
-          mvn -B -U -pl ":zeebe-process-test-qa-testcontainers" -P \!localBuild -am "-Dsurefire.rerunFailingTestsCount=5" install -DskipChecks
+          mvn -B -U -pl ":zeebe-process-test-qa-testcontainers" -P !localBuild -am "-Dsurefire.rerunFailingTestsCount=5" install -DskipChecks
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build jar
         run: |
-          mvn clean package -DskipTests -P \!localBuild -pl :zeebe-process-test-engine-agent -am
+          mvn clean package -DskipTests -P !localBuild -pl :zeebe-process-test-engine-agent -am
 
         # We build a docker image with a specific tag. There are 2 possible scenarios here.
         # 1. The workflow is triggered manually or by a change on the main branch. The tag should be 'latest'.

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build jar
         run: |
-          mvn clean package -DskipTests -pl :zeebe-process-test-engine-agent -am
+          mvn clean package -DskipTests -P \!localBuild -pl :zeebe-process-test-engine-agent -am
 
         # We build a docker image with a specific tag. There are 2 possible scenarios here.
         # 1. The workflow is triggered manually or by a change on the main branch. The tag should be 'latest'.

--- a/engine-agent/pom.xml
+++ b/engine-agent/pom.xml
@@ -110,27 +110,40 @@
           <ignoreUnusedRuntime>true</ignoreUnusedRuntime>
         </configuration>
       </plugin>
-
-      <plugin>
-        <groupId>com.google.cloud.tools</groupId>
-        <artifactId>jib-maven-plugin</artifactId>
-        <version>3.2.1</version>
-        <configuration>
-          <to>
-            <image>camunda/zeebe-process-test-engine</image>
-            <tags>${project.version}</tags>
-          </to>
-        </configuration>
-        <executions>
-          <execution>
-            <id>build-local</id>
-            <goals>
-              <goal>dockerBuild</goal>
-            </goals>
-            <phase>verify</phase>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>localBuild</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.google.cloud.tools</groupId>
+            <artifactId>jib-maven-plugin</artifactId>
+            <version>3.2.1</version>
+            <configuration>
+              <to>
+                <image>camunda/zeebe-process-test-engine</image>
+                <tags>${project.version}</tags>
+              </to>
+            </configuration>
+            <executions>
+              <execution>
+                <id>build-local</id>
+                <goals>
+                  <goal>dockerBuild</goal>
+                </goals>
+                <phase>verify</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/engine-agent/pom.xml
+++ b/engine-agent/pom.xml
@@ -110,6 +110,27 @@
           <ignoreUnusedRuntime>true</ignoreUnusedRuntime>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <version>3.2.1</version>
+        <configuration>
+          <to>
+            <image>camunda/zeebe-process-test-engine</image>
+            <tags>${project.version}</tags>
+          </to>
+        </configuration>
+        <executions>
+          <execution>
+            <id>build-local</id>
+            <goals>
+              <goal>dockerBuild</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
## Description

For local builds (on a developer's workstation) a Docker image is built by Maven on the fly. This image is then used in QA tests with testcontainers. All tests locally will be run with Java 17.

The GitHub workflows should be unperturbed by this change.

## Review hints
Please have a look at the issue for the intended scope of the change.

I think there could be further steps to also use Maven to build the Docker image as part of the GHA workflows, but I wanted to keep the change set small.

Now, effectively Maven will build a local Docker image that is tagged with the project version and GHA for build and test will build a Docker image that is tagged with the SHA value. So the two shouldn't conflict with each other :crossed_fingers: 

I was also wondering whether we should document this https://github.com/camunda/zeebe-process-test/issues/407#issuecomment-1157568109 as part of some developer documentation. Basically, I always need an hour or two to wrap my head around how this works in detail. It is easy to see from the GHA workflows what is happening, but not so easy to piece together why it needs to happen in that way. Please let me know what you think.

This will also use the default time stamping for the created images. Please read the reasoning here: https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#why-is-my-image-created-48-years-ago I opted not to deviate from the default. Again, please let me know what you think

## Related issues

closes #407 

<!-- Cut-off marker

## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
