### PR TITLE
Log PROCESS_INSTANCE_CREATION records with start instructions

### DIFF
--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -239,7 +239,9 @@ public class RecordStreamLogger {
         (ProcessInstanceCreationRecordValue) record.getValue();
     final StringJoiner joiner = new StringJoiner(", ", "", "");
     joiner.add(String.format("(Process id: %s)", value.getBpmnProcessId()));
-    joiner.add(logVariables(value.getVariables()));
+    if (!value.getVariables().isEmpty()) {
+      joiner.add(logVariables(value.getVariables()));
+    }
     joiner.add(logStartInstructions(value.getStartInstructions()));
     return joiner.toString();
   }

--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -125,7 +125,9 @@ public class RecordStreamLogger {
     if (record.getRecordType().equals(RecordType.EVENT)) {
       joiner.add(String.format("(Element id: %s)", value.getElementId()));
       joiner.add(String.format("(Job type: %s)", value.getType()));
-      joiner.add(logVariables(value.getVariables()));
+      if (!value.getVariables().isEmpty()) {
+        joiner.add(logVariables(value.getVariables()));
+      }
     }
     return joiner.toString();
   }

--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecor
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessEventRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue.ProcessInstanceCreationStartInstructionValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
@@ -39,9 +40,11 @@ import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -237,6 +240,7 @@ public class RecordStreamLogger {
     final StringJoiner joiner = new StringJoiner(", ", "", "");
     joiner.add(String.format("(Process id: %s)", value.getBpmnProcessId()));
     joiner.add(logVariables(value.getVariables()));
+    joiner.add(logStartInstructions(value.getStartInstructions()));
     return joiner.toString();
   }
 
@@ -275,6 +279,17 @@ public class RecordStreamLogger {
     final StringJoiner joiner = new StringJoiner(", ", "[", "]");
     variables.forEach((key, value) -> joiner.add(key + " -> " + value));
     return String.format("(Variables: %s)", joiner);
+  }
+
+  private String logStartInstructions(
+      final List<ProcessInstanceCreationStartInstructionValue> startInstructions) {
+    if (startInstructions.isEmpty()) {
+      return "(default start)";
+    } else {
+      return startInstructions.stream()
+          .map(ProcessInstanceCreationStartInstructionValue::getElementId)
+          .collect(Collectors.joining(", ", "(starting before elements: ", ")"));
+    }
   }
 
   protected Map<ValueType, Function<Record<?>, String>> getValueTypeLoggers() {

--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -95,16 +95,13 @@ public class RecordStreamLogger {
 
   private void logRecords(final StringBuilder stringBuilder) {
     stringBuilder.append("The following records have been recorded during this test:");
-    recordStream
-        .records()
-        .forEach(
-            record -> {
-              stringBuilder.append(logGenericRecord(record));
-              stringBuilder.append(
-                  valueTypeLoggers.getOrDefault(record.getValueType(), var -> "").apply(record));
-            });
+    recordStream.records().forEach(record -> stringBuilder.append(logRecord(record)));
 
     LOG.info(stringBuilder.toString());
+  }
+
+  protected String logRecord(final Record<?> record) {
+    return logGenericRecord(record) + logRecordDetails(record);
   }
 
   private String logGenericRecord(final Record<?> record) {
@@ -112,6 +109,10 @@ public class RecordStreamLogger {
         + String.format("| %-20s", record.getRecordType())
         + String.format("%-35s", record.getValueType())
         + String.format("%-30s| ", record.getIntent());
+  }
+
+  private String logRecordDetails(final Record<?> record) {
+    return valueTypeLoggers.getOrDefault(record.getValueType(), var -> "").apply(record);
   }
 
   private String logJobRecordValue(final Record<?> record) {

--- a/filters/src/test/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLoggerTest.java
+++ b/filters/src/test/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLoggerTest.java
@@ -123,6 +123,27 @@ class RecordStreamLoggerTest {
             "(Process id: PROCESS), (default start)"),
         Arguments.of(
             Named.of(
+                "PROCESS_INSTANCE_CREATION starting at default none start event with variables",
+                ImmutableRecord.builder()
+                    .withRecordType(RecordType.EVENT)
+                    .withValueType(ValueType.PROCESS_INSTANCE_CREATION)
+                    .withIntent(ProcessInstanceCreationIntent.CREATED)
+                    .withKey(123)
+                    .withValue(
+                        ImmutableProcessInstanceCreationRecordValue.builder()
+                            .withBpmnProcessId("PROCESS")
+                            .withVersion(1)
+                            .withVariables(
+                                new HashMap<String, Object>() {
+                                  {
+                                    put("key", "value");
+                                  }
+                                })
+                            .build())
+                    .build()),
+            "(Process id: PROCESS), (Variables: [key -> value]), (default start)"),
+        Arguments.of(
+            Named.of(
                 "PROCESS_INSTANCE_CREATEION starting at given elements",
                 ImmutableRecord.builder()
                     .withRecordType(RecordType.EVENT)

--- a/filters/src/test/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLoggerTest.java
+++ b/filters/src/test/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLoggerTest.java
@@ -21,7 +21,9 @@ import io.camunda.zeebe.protocol.record.ImmutableRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceCreationStartInstructionValue;
 import java.util.Arrays;
@@ -164,6 +166,21 @@ class RecordStreamLoggerTest {
                                     .build())
                             .build())
                     .build()),
-            "(Process id: PROCESS), (starting before elements: USER_TASK, SERVICE_TASK)"));
+            "(Process id: PROCESS), (starting before elements: USER_TASK, SERVICE_TASK)"),
+        Arguments.of(
+            Named.of(
+                "JOB with element id and type",
+                ImmutableRecord.builder()
+                    .withRecordType(RecordType.EVENT)
+                    .withValueType(ValueType.JOB)
+                    .withIntent(JobIntent.COMPLETED)
+                    .withKey(123)
+                    .withValue(
+                        ImmutableJobRecordValue.builder()
+                            .withType("task")
+                            .withElementId("serviceTask1")
+                            .build())
+                    .build()),
+            "(Element id: serviceTask1), (Job type: task)"));
   }
 }

--- a/filters/src/test/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLoggerTest.java
+++ b/filters/src/test/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLoggerTest.java
@@ -120,7 +120,7 @@ class RecordStreamLoggerTest {
                             .withVersion(1)
                             .build())
                     .build()),
-            "(Process id: PROCESS), , (default start)"),
+            "(Process id: PROCESS), (default start)"),
         Arguments.of(
             Named.of(
                 "PROCESS_INSTANCE_CREATEION starting at given elements",
@@ -143,6 +143,6 @@ class RecordStreamLoggerTest {
                                     .build())
                             .build())
                     .build()),
-            "(Process id: PROCESS), , (starting before elements: USER_TASK, SERVICE_TASK)"));
+            "(Process id: PROCESS), (starting before elements: USER_TASK, SERVICE_TASK)"));
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Expands the RecordLogger to also log the start instructions of `PROCESS_INSTANCE_CREATION` records.

Also adds easier testing to the RecordStreamLoggerTest.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #411

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
