### PR TITLE
feat: get engine time

### DIFF
--- a/api/revapi.json
+++ b/api/revapi.json
@@ -10,5 +10,19 @@
         ]
       }
     }
+  },
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "justification": "This change is necessary to implement #446",
+      "criticality": "highlight",
+      "differences": [
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method long io.camunda.zeebe.process.test.api.ZeebeTestEngine::getEngineTime()",
+          "justification": "As part of #446, we need a new API to access the engine's current time."
+        }
+      ]
+    }
   }
 ]

--- a/api/revapi.json
+++ b/api/revapi.json
@@ -19,7 +19,7 @@
       "differences": [
         {
           "code": "java.method.addedToInterface",
-          "new": "method long io.camunda.zeebe.process.test.api.ZeebeTestEngine::getEngineTime()",
+          "new": "method long io.camunda.zeebe.process.test.api.ZeebeTestEngine::getTime()",
           "justification": "As part of #446, we need a new API to access the engine's current time."
         }
       ]

--- a/api/src/main/java/io/camunda/zeebe/process/test/api/ZeebeTestEngine.java
+++ b/api/src/main/java/io/camunda/zeebe/process/test/api/ZeebeTestEngine.java
@@ -87,4 +87,12 @@ public interface ZeebeTestEngine {
    * @throws TimeoutException if the engine has not reached a busy state before the timeout
    */
   void waitForBusyState(Duration timeout) throws InterruptedException, TimeoutException;
+
+  /**
+   * Gets the current engine time. Can be used in conjunction with increaseTime to set a specific
+   * time in the future.
+   *
+   * @return the current time of the engine in milliseconds since the epoch.
+   */
+  long getEngineTime();
 }

--- a/api/src/main/java/io/camunda/zeebe/process/test/api/ZeebeTestEngine.java
+++ b/api/src/main/java/io/camunda/zeebe/process/test/api/ZeebeTestEngine.java
@@ -94,5 +94,5 @@ public interface ZeebeTestEngine {
    *
    * @return the current time of the engine in milliseconds since the epoch.
    */
-  long getEngineTime();
+  long getTime();
 }

--- a/engine-agent/src/main/java/io/camunda/zeebe/process/test/engine/agent/EngineControlImpl.java
+++ b/engine-agent/src/main/java/io/camunda/zeebe/process/test/engine/agent/EngineControlImpl.java
@@ -11,6 +11,8 @@ import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.engine.EngineFactory;
 import io.camunda.zeebe.process.test.engine.protocol.EngineControlGrpc.EngineControlImplBase;
 import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.GetRecordsRequest;
+import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.GetTimeRequest;
+import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.GetTimeResponse;
 import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.IncreaseTimeRequest;
 import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.IncreaseTimeResponse;
 import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.RecordResponse;
@@ -81,6 +83,13 @@ public final class EngineControlImpl extends EngineControlImplBase {
     engine.increaseTime(Duration.ofMillis(request.getMilliseconds()));
     final IncreaseTimeResponse response = IncreaseTimeResponse.newBuilder().build();
     responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void getTime(
+      final GetTimeRequest request, final StreamObserver<GetTimeResponse> responseObserver) {
+    responseObserver.onNext(GetTimeResponse.newBuilder().setTime(engine.getTime()).build());
     responseObserver.onCompleted();
   }
 

--- a/engine-protocol/src/main/proto/engine_control.proto
+++ b/engine-protocol/src/main/proto/engine_control.proto
@@ -47,11 +47,11 @@ message RecordResponse {
   string recordJson = 1;
 }
 
-message GetEngineTimeRequest {}
+message GetTimeRequest {}
 
-message GetEngineTimeResponse {
+message GetTimeResponse {
   // Current time in milliseconds since the epoch
-  int64 currentTime = 1;
+  int64 time = 1;
 }
 
 service EngineControl {
@@ -109,5 +109,5 @@ service EngineControl {
     Gets the current engine time. This can be used in conjunction with
     IncreaseTime to set a specific engine time.
    */
-  rpc GetEngineTime (GetEngineTimeRequest) returns (GetEngineTimeResponse);
+  rpc GetTime (GetTimeRequest) returns (GetTimeResponse);
 }

--- a/engine-protocol/src/main/proto/engine_control.proto
+++ b/engine-protocol/src/main/proto/engine_control.proto
@@ -21,7 +21,8 @@ message IncreaseTimeRequest {
   int32 milliseconds = 1;
 }
 
-message IncreaseTimeResponse {}
+message IncreaseTimeResponse {
+}
 
 message WaitForIdleStateRequest {
   // timeout (in ms). The request will be closed if an idle state has not been
@@ -44,6 +45,13 @@ message GetRecordsRequest {}
 message RecordResponse {
   // A JSON representation of a Record.
   string recordJson = 1;
+}
+
+message GetEngineTimeRequest {}
+
+message GetEngineTimeResponse {
+  // Current time in milliseconds since the epoch
+  int64 currentTime = 1;
 }
 
 service EngineControl {
@@ -97,4 +105,9 @@ service EngineControl {
    */
   rpc GetRecords (GetRecordsRequest) returns (stream RecordResponse);
 
+  /*
+    Gets the current engine time. This can be used in conjunction with
+    IncreaseTime to set a specific engine time.
+   */
+  rpc GetEngineTime (GetEngineTimeRequest) returns (GetEngineTimeResponse);
 }

--- a/engine-protocol/src/main/proto/proto.lock
+++ b/engine-protocol/src/main/proto/proto.lock
@@ -75,14 +75,14 @@
             ]
           },
           {
-            "name": "GetEngineTimeRequest"
+            "name": "GetTimeRequest"
           },
           {
-            "name": "GetEngineTimeResponse",
+            "name": "GetTimeResponse",
             "fields": [
               {
                 "id": 1,
-                "name": "currentTime",
+                "name": "time",
                 "type": "int64"
               }
             ]
@@ -129,9 +129,9 @@
                 "out_streamed": true
               },
               {
-                "name": "GetEngineTime",
-                "in_type": "GetEngineTimeRequest",
-                "out_type": "GetEngineTimeResponse"
+                "name": "GetTime",
+                "in_type": "GetTimeRequest",
+                "out_type": "GetTimeResponse"
               }
             ]
           }

--- a/engine-protocol/src/main/proto/proto.lock
+++ b/engine-protocol/src/main/proto/proto.lock
@@ -73,6 +73,19 @@
                 "type": "string"
               }
             ]
+          },
+          {
+            "name": "GetEngineTimeRequest"
+          },
+          {
+            "name": "GetEngineTimeResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "currentTime",
+                "type": "int64"
+              }
+            ]
           }
         ],
         "services": [
@@ -114,6 +127,11 @@
                 "in_type": "GetRecordsRequest",
                 "out_type": "RecordResponse",
                 "out_streamed": true
+              },
+              {
+                "name": "GetEngineTime",
+                "in_type": "GetEngineTimeRequest",
+                "out_type": "GetEngineTimeResponse"
               }
             ]
           }

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryEngine.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryEngine.java
@@ -112,6 +112,11 @@ class InMemoryEngine implements ZeebeTestEngine {
   }
 
   @Override
+  public long getEngineTime() {
+    return clock.getCurrentTimeInMillis();
+  }
+
+  @Override
   public void waitForIdleState(final Duration timeout)
       throws InterruptedException, TimeoutException {
     final CompletableFuture<Void> idleState = new CompletableFuture<>();

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryEngine.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryEngine.java
@@ -112,7 +112,7 @@ class InMemoryEngine implements ZeebeTestEngine {
   }
 
   @Override
-  public long getEngineTime() {
+  public long getTime() {
     return clock.getCurrentTimeInMillis();
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import org.assertj.core.data.Offset;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -843,13 +844,12 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldQueryTheTime() throws InterruptedException {
-    long start = zeebeEngine.getEngineTime();
-    Thread.sleep(10);
-    assertThat(zeebeEngine.getEngineTime() > start).isTrue();
+  public void shouldQueryTheTime() {
+    final long startTime = zeebeEngine.getTime();
+    assertThat(startTime).isCloseTo(System.currentTimeMillis(), Offset.offset(50L));
 
-    // Increase time in the engine and make sure time advances by a similar amount.
-    zeebeEngine.increaseTime(Duration.ofSeconds(1));
-    assertThat(zeebeEngine.getEngineTime() - start).isGreaterThan(1000);
+    zeebeEngine.increaseTime(Duration.ofHours(1));
+    final long secondTime = zeebeEngine.getTime();
+    assertThat(secondTime).isCloseTo(System.currentTimeMillis() + 3600 * 1000, Offset.offset(50L));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
@@ -841,4 +841,15 @@ class EngineClientTest {
               assertThat(processCompleted).isNotEmpty();
             });
   }
+
+  @Test
+  public void shouldQueryTheTime() throws InterruptedException {
+    long start = zeebeEngine.getEngineTime();
+    Thread.sleep(10);
+    assertThat(zeebeEngine.getEngineTime() > start).isTrue();
+
+    // Increase time in the engine and make sure time advances by a similar amount.
+    zeebeEngine.increaseTime(Duration.ofSeconds(1));
+    assertThat(zeebeEngine.getEngineTime() - start).isGreaterThan(1000);
+  }
 }

--- a/extension-testcontainer/src/main/java/io.camunda.zeebe.process.test.extension.testcontainer/ContainerizedEngine.java
+++ b/extension-testcontainer/src/main/java/io.camunda.zeebe.process.test.extension.testcontainer/ContainerizedEngine.java
@@ -23,6 +23,8 @@ import io.camunda.zeebe.process.test.api.RecordStreamSource;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.engine.protocol.EngineControlGrpc;
 import io.camunda.zeebe.process.test.engine.protocol.EngineControlGrpc.EngineControlBlockingStub;
+import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.GetEngineTimeRequest;
+import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.GetEngineTimeResponse;
 import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.GetRecordsRequest;
 import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.IncreaseTimeRequest;
 import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.RecordResponse;
@@ -115,6 +117,16 @@ public class ContainerizedEngine implements ZeebeTestEngine {
     stub.increaseTime(request);
 
     closeChannel(channel);
+  }
+
+  @Override
+  public long getEngineTime() {
+    final ManagedChannel channel = getChannel();
+    final EngineControlBlockingStub stub = getStub(channel);
+
+    final GetEngineTimeRequest request = GetEngineTimeRequest.newBuilder().build();
+    final GetEngineTimeResponse response = stub.getEngineTime(request);
+    return response.getCurrentTime();
   }
 
   @Override

--- a/extension-testcontainer/src/main/java/io.camunda.zeebe.process.test.extension.testcontainer/ContainerizedEngine.java
+++ b/extension-testcontainer/src/main/java/io.camunda.zeebe.process.test.extension.testcontainer/ContainerizedEngine.java
@@ -23,9 +23,9 @@ import io.camunda.zeebe.process.test.api.RecordStreamSource;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.engine.protocol.EngineControlGrpc;
 import io.camunda.zeebe.process.test.engine.protocol.EngineControlGrpc.EngineControlBlockingStub;
-import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.GetEngineTimeRequest;
-import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.GetEngineTimeResponse;
 import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.GetRecordsRequest;
+import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.GetTimeRequest;
+import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.GetTimeResponse;
 import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.IncreaseTimeRequest;
 import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.RecordResponse;
 import io.camunda.zeebe.process.test.engine.protocol.EngineControlOuterClass.ResetEngineRequest;
@@ -120,13 +120,17 @@ public class ContainerizedEngine implements ZeebeTestEngine {
   }
 
   @Override
-  public long getEngineTime() {
+  public long getTime() {
     final ManagedChannel channel = getChannel();
-    final EngineControlBlockingStub stub = getStub(channel);
+    try {
+      final EngineControlBlockingStub stub = getStub(channel);
 
-    final GetEngineTimeRequest request = GetEngineTimeRequest.newBuilder().build();
-    final GetEngineTimeResponse response = stub.getEngineTime(request);
-    return response.getCurrentTime();
+      final GetTimeRequest request = GetTimeRequest.newBuilder().build();
+      final GetTimeResponse response = stub.getTime(request);
+      return response.getTime();
+    } finally {
+      closeChannel(channel);
+    }
   }
 
   @Override


### PR DESCRIPTION


## Description

Implement a new API for the test engine that allows the test writer to query
the current time of the running engine. This helps to create tests that set
a specific time-of-day, especially for longer-running tests where there may
be multiple changes in the engine clock.

## Related issues

closes #446 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [X] Javadoc has been written
* [ ] The documentation is updated
