### PR TITLE
chore(ci): update GHA secrets to new Vault path

### DIFF
--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -36,10 +36,10 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/common/github.com/actions/camunda/zeebe-process-test REGISTRY_HUB_DOCKER_COM_USR;
-            secret/data/common/github.com/actions/camunda/zeebe-process-test REGISTRY_HUB_DOCKER_COM_PSW;
-            secret/data/common/github.com/actions/camunda/zeebe-process-test ARTIFACTS_USR;
-            secret/data/common/github.com/actions/camunda/zeebe-process-test ARTIFACTS_PSW;
+            secret/data/products/zeebe/ci/zeebe-process-test REGISTRY_HUB_DOCKER_COM_USR;
+            secret/data/products/zeebe/ci/zeebe-process-test REGISTRY_HUB_DOCKER_COM_PSW;
+            secret/data/products/zeebe/ci/zeebe-process-test ARTIFACTS_USR;
+            secret/data/products/zeebe/ci/zeebe-process-test ARTIFACTS_PSW;
             secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_USR;
             secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_PSW;
             secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE;


### PR DESCRIPTION
## Description

related to a [recent announcement](https://camunda.slack.com/archives/C03AEFWGJ9K/p1657524606321389) of restructuring Vault.

Secrets have already been copied over to: https://vault.int.camunda.com/ui/vault/secrets/secret/list/products/zeebe/ci/


## Related issues

related to [INFRA-3336](https://jira.camunda.com/browse/INFRA-3336)

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
