### PR TITLE
Daily test against Zeebe SNAPSHOT version

### DIFF
--- a/.github/workflows/snapshot-test.yml
+++ b/.github/workflows/snapshot-test.yml
@@ -38,3 +38,38 @@ jobs:
           name: Unit Test Results Against Zeebe Snapshot
           path: "*/target/surefire-reports/"
           retention-days: 7
+
+  notify-if-failed:
+    name: Send slack notification on build failure
+    runs-on: ubuntu-latest
+    needs: [test-against-zeebe-snapshot]
+    if: failure()
+    steps:
+      - id: slack-notify
+        name: Send slack notification
+        uses: slackapi/slack-github-action@v1.21.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "text": ":alarm: `zeebe-process-test` build against Zeebe SNAPSHOT version failed! :alarm:",
+             	"blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: `zeebe-process-test` build against Zeebe SNAPSHOT version failed! :alarm:"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Please check the related workflow (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) and fix it before it blocks the upcoming release!\n  \\cc @zeebe-medic"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/snapshot-test.yml
+++ b/.github/workflows/snapshot-test.yml
@@ -1,0 +1,40 @@
+name: Zeebe SNAPSHOT test
+on:
+  workflow_call: { }
+  schedule:
+    - cron: "0 3 * * *"
+jobs:
+  test-against-zeebe-snapshot:
+    name: Run tests against Zeebe SNAPSHOT version
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Java environment
+        uses: actions/setup-java@v3.4.1
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      - name: Build with Zeebe SNAPSHOT version
+        run: |
+          CURRENT_ZEEBE_VERSION=$(mvn help:evaluate -Dexpression=dependency.zeebe.version -DforceStdout -q)
+          if grep -q "alpha" <<< "$CURRENT_ZEEBE_VERSION"; then
+            NEW_ZEEBE_VERSION=$(echo $CURRENT_ZEEBE_VERSION | sed "s/alpha.*/SNAPSHOT/")
+          else
+            NEW_ZEEBE_VERSION=$(echo $CURRENT_ZEEBE_VERSION | awk -F. '/[0-9]+\./{$2++;print}' OFS=.)
+          fi
+          echo $NEW_ZEEBE_VERSION
+          mvn -B -U -pl "-:zeebe-process-test-qa-testcontainers" -P !localBuild "-Dsurefire.rerunFailingTestsCount=5" -Ddependency.zeebe.version=$NEW_ZEEBE_VERSION clean install
+
+      - name: Archive Test Results
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Unit Test Results Against Zeebe Snapshot
+          path: "*/target/surefire-reports/"
+          retention-days: 7

--- a/.github/workflows/snapshot-test.yml
+++ b/.github/workflows/snapshot-test.yml
@@ -26,7 +26,7 @@ jobs:
           if grep -q "alpha" <<< "$CURRENT_ZEEBE_VERSION"; then
             NEW_ZEEBE_VERSION=$(echo $CURRENT_ZEEBE_VERSION | sed "s/alpha.*/SNAPSHOT/")
           else
-            NEW_ZEEBE_VERSION=$(echo $CURRENT_ZEEBE_VERSION | awk -F. '/[0-9]+\./{$2++;print}' OFS=.)
+            NEW_ZEEBE_VERSION=echo $(echo $CURRENT_ZEEBE_VERSION | awk -F. '/[0-9]+\./{$2++;print}' OFS=.)-SNAPSHOT
           fi
           echo $NEW_ZEEBE_VERSION
           mvn -B -U -pl "-:zeebe-process-test-qa-testcontainers" -P !localBuild "-Dsurefire.rerunFailingTestsCount=5" -Ddependency.zeebe.version=$NEW_ZEEBE_VERSION clean install

--- a/pom.xml
+++ b/pom.xml
@@ -416,6 +416,16 @@
     </dependencies>
   </dependencyManagement>
 
+  <repositories>
+    <repository>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>camunda-nexus</id>
+      <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
+    </repository>
+  </repositories>
+
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

We've encountered problems during the release multiple times, because Zeebe contained breaking changes for Zeebe Process Test. By building and running our tests we can identify these problems earlier on in the development process and don't have to fix these during the release process.

Logically we have to decide in the workflow what the next Zeebe SNAPSHOT version will be from the current Zeebe version defined in the pom. There is 2 options for the current version:

1. No alpha version: MAJOR.MINOR.PATCH
2. Alpha version: MAJOR.MINOR.PATCH-alphaX

When it is not an alpha version we need to increment the MINOR version by 1 and append `-SNAPSHOT` at the end. When it is an alpha version we need to replace `alphaX` with `SNAPSHOT`.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #465

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
