### PR TITLE
build(deps): revert zeebe version to SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <dependency.snakeyaml.version>1.31</dependency.snakeyaml.version>
     <dependency.spring.version>5.3.22</dependency.spring.version>
     <dependency.testcontainers.version>1.17.3</dependency.testcontainers.version>
-    <dependency.zeebe.version>8.1.0-alpha5</dependency.zeebe.version>
+    <dependency.zeebe.version>8.1.0-SNAPSHOT</dependency.zeebe.version>
 
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
 


### PR DESCRIPTION
## Description

alpha5 is released. Revert zeebe version to SNAPSHOT to allow continued development.

Related  https://github.com/camunda/zeebe-process-test/pull/489#pullrequestreview-1099236970

