### PR TITLE
Fix version decision command

### DIFF
--- a/.github/workflows/snapshot-test.yml
+++ b/.github/workflows/snapshot-test.yml
@@ -28,7 +28,7 @@ jobs:
           elif grep -q "SNAPSHOT" <<< "$CURRENT_ZEEBE_VERSION"; then
             NEW_ZEEBE_VERSION=$CURRENT_ZEEBE_VERSION
           else
-            NEW_ZEEBE_VERSION=echo $(echo $CURRENT_ZEEBE_VERSION | awk -F. '/[0-9]+\./{$2++;print}' OFS=.)-SNAPSHOT
+            NEW_ZEEBE_VERSION=`echo $CURRENT_ZEEBE_VERSION | awk -F. '/[0-9]+\./{$2++;print}' OFS=.`-SNAPSHOT
           fi
           echo $NEW_ZEEBE_VERSION
           mvn -B -U -pl "-:zeebe-process-test-qa-testcontainers" -P !localBuild "-Dsurefire.rerunFailingTestsCount=5" -Ddependency.zeebe.version=$NEW_ZEEBE_VERSION clean install


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The command to increase the Zeebe minor by 1 and appending -SNAPSHOT was broken. `            NEW_ZEEBE_VERSION=echo $(echo $CURRENT_ZEEBE_VERSION | awk -F. '/[0-9]+\./{$2++;print}' OFS=.)-SNAPSHOT` would result in bash trying to execute the version. This would result in the message that 8.2.0-SNAPSHOT is not a command:
<img width="880" alt="image" src="https://user-images.githubusercontent.com/5787702/194005107-5e2eb84f-61b4-46e8-a7cb-769ef07d5d26.png">


By moving the $() outward and using backticks this problem is resolved. `NEW_ZEEBE_VERSION=$(echo `echo $CURRENT_ZEEBE_VERSION | awk -F. '/[0-9]+\./{$2++;print}' OFS=.`-SNAPSHOT)` will echo the version instead of trying to execute it.
<img width="819" alt="image" src="https://user-images.githubusercontent.com/5787702/194005320-d059be40-8a2d-485e-b688-d1c5962f5a83.png">


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
