### PR TITLE
Add Bors to merge pull requests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,9 @@
 name: Build and test
 on:
   pull_request: { }
+  push:
+    branches:
+      - 'staging'
   workflow_call: { }
 jobs:
   code-formatting:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -118,6 +118,18 @@ jobs:
           path: "*/target/surefire-reports/"
           retention-days: 7
 
+  test-summary:
+    # Used by bors to check all tests, including the unit test matrix.
+    # New test jobs must be added to the `needs` lists!
+    # This name is hard-referenced from bors.toml; remember to update that if this name changes
+    name: Test summary
+    runs-on: ubuntu-latest
+    needs:
+      - code-formatting
+      - build-and-test-embedded
+      - build-and-test-testcontainers
+    steps:
+      - run: exit 0
 
   # We need to upload the event file as an artifact in order to support publishing the results of
 # forked repositories (https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches)

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,9 @@
+status = [
+    "Test summary",
+]
+
+required_approvals = 1
+
+delete_merged_branches = true
+
+commit_title = "merge: ${PR_REFS}"


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This adds [bors](https://github.com/bors-ng/bors-ng) support to this repo.

- runs the CI on a push to `staging` (typically what bors does when instructed to merge a pull request)
- adds a special job that bors can await
- configures bors only to fast-forward the target branch to the merge commit if this job succeeds

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #536

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
