### PR TITLE
Fix dmn model dependency convergence issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <dependency.assertj.version>3.23.1</dependency.assertj.version>
     <dependency.awaitility.version>4.2.0</dependency.awaitility.version>
     <dependency.bytebuddy.version>1.12.18</dependency.bytebuddy.version>
+    <dependency.camundamodel.version>7.18.0</dependency.camundamodel.version>
     <dependency.classgraph.version>4.8.149</dependency.classgraph.version>
     <dependency.commons.version>3.12.0</dependency.commons.version>
     <dependency.errorprone.version>2.16</dependency.errorprone.version>
@@ -73,7 +74,7 @@
     <dependency.snakeyaml.version>1.33</dependency.snakeyaml.version>
     <dependency.spring.version>5.3.23</dependency.spring.version>
     <dependency.testcontainers.version>1.17.5</dependency.testcontainers.version>
-    <dependency.zeebe.version>8.1.0</dependency.zeebe.version>
+    <dependency.zeebe.version>8.2.0-SNAPSHOT</dependency.zeebe.version>
 
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
 
@@ -229,7 +230,7 @@
       <dependency>
         <groupId>org.camunda.bpm.model</groupId>
         <artifactId>camunda-dmn-model</artifactId>
-        <version>7.17.0</version>
+        <version>${dependency.camundamodel.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The Zeebe version is set to the SNAPSHOT version in order to resolve this issue. If we don't the main branch would expect version 7.17.0 of the dmn-model. The nightly tests against SNAPSHOT would expect version 7.18.0. Whichever version we'd pick, one of those would always be broken. By changing te main branch to Zeebe SNAPSHOT we resolve this issue.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #538

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
