### PR TITLE
[Backport stable/8.0] Add Bors to merge pull requests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,9 @@
 name: Build and test
 on:
   pull_request: { }
+  push:
+    branches:
+      - 'staging'
   workflow_call: { }
 jobs:
   code-formatting:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -108,6 +108,18 @@ jobs:
           path: "*/target/surefire-reports/"
           retention-days: 7
 
+  test-summary:
+    # Used by bors to check all tests, including the unit test matrix.
+    # New test jobs must be added to the `needs` lists!
+    # This name is hard-referenced from bors.toml; remember to update that if this name changes
+    name: Test summary
+    runs-on: ubuntu-latest
+    needs:
+      - code-formatting
+      - build-and-test-embedded
+      - build-and-test-testcontainers
+    steps:
+      - run: exit 0
 
   # We need to upload the event file as an artifact in order to support publishing the results of
 # forked repositories (https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches)

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - code-formatting
-      - build-and-test-embedded
+      - build-and-test
       - build-and-test-testcontainers
     steps:
       - run: exit 0

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,9 @@
+status = [
+    "Test summary",
+]
+
+required_approvals = 1
+
+delete_merged_branches = true
+
+commit_title = "merge: ${PR_REFS}"


### PR DESCRIPTION
# Description
Backport of #537 to `stable/8.0`.

relates to #536

Backported manually because there was a failure in the backport-action. Although the cherry-pick was without conflicts: `git cherry-pick -x 9810bb45d4d5a677ded129cd9a3d9996c2f7559e 2ff389d9e28ff9d5d44278a18adc297a24981e19 b577b164dc55fe92e7314e13b87f5d9b253cbf82`, I still needed to fix the CI. Specifically one of the jobs has a different name.