### PR TITLE
fix(filters): add escalation valuetype logger

### DIFF
--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
+import io.camunda.zeebe.protocol.record.value.EscalationRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
@@ -83,6 +84,7 @@ public class RecordStreamLogger {
         ValueType.PROCESS_INSTANCE_RESULT, this::logProcessInstanceResultRecordValue);
     valueTypeLoggers.put(ValueType.PROCESS, this::logProcessRecordValue);
     valueTypeLoggers.put(ValueType.PROCESS_EVENT, this::logProcessEventRecordValue);
+    valueTypeLoggers.put(ValueType.ESCALATION, this::logEscalationRecordValue);
 
     // These records don't have any interesting extra information for the user to log
     valueTypeLoggers.put(ValueType.DEPLOYMENT_DISTRIBUTION, record -> "");
@@ -282,6 +284,16 @@ public class RecordStreamLogger {
     final StringJoiner joiner = new StringJoiner(", ", "", "");
     joiner.add(String.format("(Target element id: %s)", value.getTargetElementId()));
     joiner.add(logVariables(value.getVariables()));
+    return joiner.toString();
+  }
+
+  private String logEscalationRecordValue(final Record<?> record) {
+    final EscalationRecordValue value = (EscalationRecordValue) record.getValue();
+    final StringJoiner joiner = new StringJoiner(", ", "", "");
+    joiner.add(String.format("(Process id: %s)", value.getProcessInstanceKey()));
+    joiner.add(String.format("(Escalation code: %s)", value.getEscalationCode()));
+    joiner.add(String.format("(Throw element id: %s)", value.getThrowElementId()));
+    joiner.add(String.format("(Catch element id: %s)", value.getCatchElementId()));
     return joiner.toString();
   }
 


### PR DESCRIPTION
## Description

Add a logger for the Escalation ValueType. The Escalation ValueType was added recently, and there is no corresponding logger in the zeebe-process-test library. This causes the testAllValueTypesAreMapped() test to fail.

## Related issues

closes #551

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [ ] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
