### PR TITLE
Remove caching from the Zeebe SNAPSHOT tests

### DIFF
--- a/.github/workflows/snapshot-test.yml
+++ b/.github/workflows/snapshot-test.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-          cache: maven
 
       - name: Build with Zeebe SNAPSHOT version
         run: |


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The Zeebe SNAPSHOT tests are supposed to verify that zeebe-process-test is compatibly with the latest changes in Zeebe. It runs daily to make sure nothing has broken. Caching messes this up. If we restore the cache we are no longer testing against the latest changes. We might be testing against an older cache, missing any changes that could break this project.


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
