### PR TITLE
fix: adjust logstream writer usage after refactoring

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/CommandWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/CommandWriter.java
@@ -8,29 +8,28 @@
 
 package io.camunda.zeebe.process.test.engine;
 
-import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
+import io.camunda.zeebe.logstreams.log.LogAppendEntry;
+import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 
 /**
- * This record is responsible for writing the commands to the {@link LogStreamRecordWriter} in a
+ * This record is responsible for writing the commands to the {@link LogStreamWriter} in a
  * thread-safe way.
  */
-record CommandWriter(LogStreamRecordWriter writer) {
+record CommandWriter(LogStreamWriter writer) {
 
   void writeCommandWithKey(
       final Long key, final BufferWriter bufferWriter, final RecordMetadata recordMetadata) {
     synchronized (writer) {
-      writer.reset();
-      writer.key(key).metadataWriter(recordMetadata).valueWriter(bufferWriter).tryWrite();
+      writer.tryWrite(LogAppendEntry.of(key, recordMetadata, bufferWriter));
     }
   }
 
   void writeCommandWithoutKey(
       final BufferWriter bufferWriter, final RecordMetadata recordMetadata) {
     synchronized (writer) {
-      writer.reset();
-      writer.keyNull().metadataWriter(recordMetadata).valueWriter(bufferWriter).tryWrite();
+      writer.tryWrite(LogAppendEntry.of(recordMetadata, bufferWriter));
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
@@ -59,8 +59,7 @@ public class EngineFactory {
     final InMemoryLogStorage logStorage = new InMemoryLogStorage();
     final LogStream logStream = createLogStream(logStorage, scheduler, partitionId);
 
-    final CommandWriter commandWriter =
-        new CommandWriter(logStream.newLogStreamRecordWriter().join());
+    final CommandWriter commandWriter = new CommandWriter(logStream.newLogStreamWriter().join());
     final CommandSender commandSender = new CommandSender(commandWriter);
     final GatewayRequestStore gatewayRequestStore = new GatewayRequestStore();
     final GrpcToLogStreamGateway gateway =


### PR DESCRIPTION
## Description

Following the refactoring in https://github.com/camunda/zeebe/pull/11115, I've updated the usage of the logstream writer API