### PR TITLE
fix(ci): Switch back to actions/setup-java@v3.6.0

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Java environment
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: temurin
           java-version: 17
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Java environment
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: temurin
           java-version: 17
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Java environment
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: temurin
           java-version: 17
@@ -100,7 +100,7 @@ jobs:
           IMAGE_TAG_KEY: container.image.tag
 
       - name: Downgrade Java environment
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: temurin
           java-version: 8

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -46,7 +46,7 @@ jobs:
             secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC;
 
       - name: Set up Java environment
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/snapshot-test.yml
+++ b/.github/workflows/snapshot-test.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Java environment
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: temurin
           java-version: 17


### PR DESCRIPTION
## Description

The version `v3.7.0` of actions/setup-java was removed. Fix the workflows by using the previous version. See https://github.com/actions/setup-java/issues/422.

## Related issues

Failed action: https://github.com/camunda/zeebe-process-test/actions/runs/3626043207

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
