### PR TITLE
ci: use major version for actions/setup-java

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Java environment
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Java environment
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Java environment
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17
@@ -100,7 +100,7 @@ jobs:
           IMAGE_TAG_KEY: container.image.tag
 
       - name: Downgrade Java environment
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 8

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -46,7 +46,7 @@ jobs:
             secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC;
 
       - name: Set up Java environment
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/snapshot-test.yml
+++ b/.github/workflows/snapshot-test.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Java environment
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Changes the version used for actions/setup-java in all workflows to major version `v3`.

This should reduce the amount of effort needed to update this action (i.e. no more dependabot pull requests unless a new major version is released).

It should also avoid problems when actions/setup-java removes a specific patch release tag (as has happened before, see pull request mentioned below).

Using a major version is possible because GH recommends moving the major release tags along with the minor and patch releases of that same version.

Note that this may result in reduced reproducibility. However, since all tags can be moved, the only way to guarantee reproducibility is by pinning specific commit shas. Since we don't necessarily depend on a specific version, we should trust the maintainers of the action to adhere to semver.

## Related issues

<!-- Which issues are closed by this PR or are related -->

discussed in https://github.com/camunda/zeebe-process-test/pull/589#issuecomment-1338934871

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
