### PR TITLE
fix(filters): add signal subscription value type logger

### DIFF
--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordV
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
@@ -101,6 +102,8 @@ public class RecordStreamLogger {
 
     valueTypeLoggers.put(
         ValueType.PROCESS_INSTANCE_MODIFICATION, this::logProcessInstanceModificationRecordValue);
+
+    valueTypeLoggers.put(ValueType.SIGNAL_SUBSCRIPTION, this::logSignalSubscriptionRecordValue);
   }
 
   public void log() {
@@ -378,6 +381,16 @@ public class RecordStreamLogger {
           .map(String::valueOf)
           .collect(Collectors.joining(", ", "(terminating elements: ", ")"));
     }
+  }
+
+  private String logSignalSubscriptionRecordValue(final Record<?> record) {
+    final SignalSubscriptionRecordValue value = (SignalSubscriptionRecordValue) record.getValue();
+    final StringJoiner joiner = new StringJoiner(", ", "", "");
+    joiner.add(String.format("(Process id: %s)", value.getBpmnProcessId()));
+    joiner.add(String.format("(Catch event id: %s)", value.getCatchEventId()));
+    joiner.add(String.format("(Signal name: %s)", value.getSignalName()));
+    joiner.add(String.format("(Catch event instance key: %s)", value.getCatchEventInstanceKey()));
+    return joiner.toString();
   }
 
   protected Map<ValueType, Function<Record<?>, String>> getValueTypeLoggers() {


### PR DESCRIPTION

## Description

Add a logger for the SignalSubscription ValueType. The SignalSubscription ValueType was added recently, and there is no corresponding logger in the zeebe-process-test library. This causes the testAllValueTypesAreMapped() test to fail.


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #598 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
