### PR TITLE
Fixed modified interface of CommandSender

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/CommandSender.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/CommandSender.java
@@ -8,11 +8,11 @@
 package io.camunda.zeebe.process.test.engine;
 
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
-import io.camunda.zeebe.util.buffer.BufferWriter;
 
 final class CommandSender implements InterPartitionCommandSender {
   private final CommandWriter writer;
@@ -26,7 +26,7 @@ final class CommandSender implements InterPartitionCommandSender {
       final int receiverPartitionId,
       final ValueType valueType,
       final Intent intent,
-      final BufferWriter command) {
+      final UnifiedRecordValue command) {
     final RecordMetadata metadata =
         new RecordMetadata().recordType(RecordType.COMMAND).intent(intent).valueType(valueType);
     writer.writeCommandWithoutKey(command, metadata);
@@ -38,7 +38,7 @@ final class CommandSender implements InterPartitionCommandSender {
       final ValueType valueType,
       final Intent intent,
       final Long recordKey,
-      final BufferWriter command) {
+      final UnifiedRecordValue command) {
     final RecordMetadata metadata =
         new RecordMetadata().recordType(RecordType.COMMAND).intent(intent).valueType(valueType);
     writer.writeCommandWithKey(recordKey, command, metadata);

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/CommandWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/CommandWriter.java
@@ -11,7 +11,7 @@ package io.camunda.zeebe.process.test.engine;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
-import io.camunda.zeebe.util.buffer.BufferWriter;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 
 /**
  * This record is responsible for writing the commands to the {@link LogStreamWriter} in a
@@ -20,16 +20,16 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 record CommandWriter(LogStreamWriter writer) {
 
   void writeCommandWithKey(
-      final Long key, final BufferWriter bufferWriter, final RecordMetadata recordMetadata) {
+      final Long key, final UnifiedRecordValue command, final RecordMetadata recordMetadata) {
     synchronized (writer) {
-      writer.tryWrite(LogAppendEntry.of(key, recordMetadata, bufferWriter));
+      writer.tryWrite(LogAppendEntry.of(key, recordMetadata, command));
     }
   }
 
   void writeCommandWithoutKey(
-      final BufferWriter bufferWriter, final RecordMetadata recordMetadata) {
+      final UnifiedRecordValue command, final RecordMetadata recordMetadata) {
     synchronized (writer) {
-      writer.tryWrite(LogAppendEntry.of(recordMetadata, bufferWriter));
+      writer.tryWrite(LogAppendEntry.of(recordMetadata, command));
     }
   }
 }

--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordV
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
@@ -101,6 +102,8 @@ public class RecordStreamLogger {
 
     valueTypeLoggers.put(
         ValueType.PROCESS_INSTANCE_MODIFICATION, this::logProcessInstanceModificationRecordValue);
+
+    valueTypeLoggers.put(ValueType.SIGNAL_SUBSCRIPTION, this::logSignalSubscriptionRecordValue);
   }
 
   public void log() {
@@ -378,6 +381,16 @@ public class RecordStreamLogger {
           .map(String::valueOf)
           .collect(Collectors.joining(", ", "(terminating elements: ", ")"));
     }
+  }
+
+  private String logSignalSubscriptionRecordValue(final Record<?> record) {
+    final SignalSubscriptionRecordValue value = (SignalSubscriptionRecordValue) record.getValue();
+    final StringJoiner joiner = new StringJoiner(", ", "", "");
+    joiner.add(String.format("(Process id: %s)", value.getBpmnProcessId()));
+    joiner.add(String.format("(Catch event id: %s)", value.getCatchEventId()));
+    joiner.add(String.format("(Signal name: %s)", value.getSignalName()));
+    joiner.add(String.format("(Catch event instance key: %s)", value.getCatchEventInstanceKey()));
+    return joiner.toString();
   }
 
   protected Map<ValueType, Function<Record<?>, String>> getValueTypeLoggers() {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The CommandSender in Zeebe has changes its interface. We need to modify the interface here as well to prevent compilation failures.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #598 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
