### PR TITLE
Inject ZPT related fields into superclasses

### DIFF
--- a/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtension.java
+++ b/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtension.java
@@ -99,14 +99,15 @@ public class ZeebeProcessTestExtension
 
   private void injectFields(final ExtensionContext extensionContext, final Object... objects) {
     final Class<?> requiredTestClass = extensionContext.getRequiredTestClass();
-    final Field[] declaredFields = requiredTestClass.getDeclaredFields();
     for (final Object object : objects) {
-      final Optional<Field> field = getField(declaredFields, object);
+      final Optional<Field> field = getField(requiredTestClass, object);
       field.ifPresent(value -> injectField(extensionContext, value, object));
     }
   }
 
-  private Optional<Field> getField(final Field[] declaredFields, final Object object) {
+  private Optional<Field> getField(final Class<?> requiredTestClass, final Object object) {
+    final Field[] declaredFields = requiredTestClass.getDeclaredFields();
+
     final List<Field> fields =
         Arrays.stream(declaredFields)
             .filter(field -> field.getType().isInstance(object))
@@ -119,8 +120,12 @@ public class ZeebeProcessTestExtension
                   + "found %s. Please make sure at most one field of type %s has been declared in the"
                   + " test class.",
               object.getClass().getSimpleName(), fields.size(), object.getClass().getSimpleName()));
+    } else if (fields.size() == 0) {
+      final Class<?> superclass = requiredTestClass.getSuperclass();
+      return superclass == null ? Optional.empty() : getField(superclass, object);
+    } else {
+      return Optional.of(fields.get(0));
     }
-    return fields.size() == 0 ? Optional.empty() : Optional.of(fields.get(0));
   }
 
   private void injectField(

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/injection/AbstractInheritanceInjectionTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/injection/AbstractInheritanceInjectionTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2021 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.camunda.zeebe.process.test.qa.abstracts.injection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
+import org.junit.jupiter.api.Test;
+
+public abstract class AbstractInheritanceInjectionTest {
+  protected ZeebeClient client;
+  protected ZeebeTestEngine engine;
+
+  @Test
+  void testFieldsAreInjectedSuccessfully() {
+    assertThat(client).isNotNull();
+    assertThat(engine).isNotNull();
+  }
+}

--- a/qa/embedded/src/test/java/io/camunda/zeebe/process/test/qa/embedded/injection/InheritanceInjectionTest.java
+++ b/qa/embedded/src/test/java/io/camunda/zeebe/process/test/qa/embedded/injection/InheritanceInjectionTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2021 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.camunda.zeebe.process.test.qa.embedded.injection;
+
+import io.camunda.zeebe.process.test.extension.ZeebeProcessTest;
+import io.camunda.zeebe.process.test.qa.abstracts.injection.AbstractInheritanceInjectionTest;
+
+@ZeebeProcessTest
+class InheritanceInjectionTest extends AbstractInheritanceInjectionTest {}

--- a/qa/testcontainers/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/injection/InheritanceInjectionTest.java
+++ b/qa/testcontainers/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/injection/InheritanceInjectionTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2021 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.camunda.zeebe.process.test.qa.testcontainer.injection;
+
+import io.camunda.zeebe.process.test.extension.testcontainer.ZeebeProcessTest;
+import io.camunda.zeebe.process.test.qa.abstracts.injection.AbstractInheritanceInjectionTest;
+
+@ZeebeProcessTest
+class InheritanceInjectionTest extends AbstractInheritanceInjectionTest {}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The extensions should inject the engine, client and recordstream into the fields that are available. Before this only tried to inject them into the annotated class. This does not work when inheritance is used and the fields are defined on the superclass of the annotated class.

This PR changes the extensions so that it will first look on the annotated class. If it cannot find any of the annotations here, it will work it's way up to the superclass and so on until it either found a field it is able to inject, or no fields at all.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #604 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
