### PR TITLE
fix: implement InMemoryLogStorage.append

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryLogStorage.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryLogStorage.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.process.test.engine;
 
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.camunda.zeebe.logstreams.storage.LogStorageReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -31,6 +32,17 @@ class InMemoryLogStorage implements LogStorage {
   @Override
   public LogStorageReader newReader() {
     return new ListLogStorageReader();
+  }
+
+  @Override
+  public void append(
+      final long lowestPosition,
+      final long highestPosition,
+      final BufferWriter bufferWriter,
+      final AppendListener listener) {
+    final var buffer = ByteBuffer.allocate(bufferWriter.getLength());
+    bufferWriter.write(new UnsafeBuffer(buffer), 0);
+    append(lowestPosition, highestPosition, buffer, listener);
   }
 
   @Override


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This method was newly added to LogStorage to support appends of unserialized application data. But now this lead to a compilation error in ZPT because it contains a class `InMemoryLogStorage` that implements `LogStorage`.

The [implementation of the test class ListLogStorage](https://github.com/camunda/zeebe/blob/4dd1025f3f3ba86b5aec10d380b9db8550ed0967/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java#L77-L79) seemed like a reasonable solution for zeebe-process-test. It simply writes the contents of the writer into a buffer and appends it as usual.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #613

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
