### PR TITLE
Remove references to Camunda Cloud

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ _All lines under and including the cut-off marker will be removed from the merge
 
 Please check the items that apply, before requesting a review.
 
-You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).
+You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).
 
 * [ ] I've reviewed my own code
 * [ ] I've written a clear changelist description

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Zeebe Process Test
 
-This project allows you to unit test your Camunda Cloud BPMN processes. It will start a Zeebe test engine
+This project allows you to unit test your Camunda Platform 8 BPMN processes. It will start a Zeebe test engine
 and provide you with a set of assertions you can use to verify your process behaves as expected.
 
 ## Prerequisites

--- a/engine-protocol/src/main/proto/engine_control.proto
+++ b/engine-protocol/src/main/proto/engine_control.proto
@@ -93,7 +93,7 @@ service EngineControl {
     in a JSON format. Client-side these should be mapped to Records.
 
     For an easy way to serialize this JSON back to a Record please refer to:
-    https://github.com/camunda-cloud/zeebe/tree/main/protocol-jackson
+    https://github.com/camunda/zeebe/tree/main/protocol-jackson
    */
   rpc GetRecords (GetRecordsRequest) returns (stream RecordResponse);
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Removes the references to Camunda Cloud by renaming it to Camunda Platform 8, or by redirecting the camunda organisation on GitHub instead of the Camunda-cloud organisation.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #617

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [x] The documentation is updated
