### PR TITLE
Add ResourceDeletion ValueType to the logger

### DIFF
--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordV
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
@@ -106,6 +107,8 @@ public class RecordStreamLogger {
 
     valueTypeLoggers.put(ValueType.SIGNAL_SUBSCRIPTION, this::logSignalSubscriptionRecordValue);
     valueTypeLoggers.put(ValueType.SIGNAL, this::logSignalRecordValue);
+
+    valueTypeLoggers.put(ValueType.RESOURCE_DELETION, this::logResourceDeletionRecordValue);
   }
 
   public void log() {
@@ -402,6 +405,11 @@ public class RecordStreamLogger {
     joiner.add(String.format("(Signal name: %s)", value.getSignalName()));
     joiner.add(logVariables(value.getVariables()));
     return joiner.toString();
+  }
+
+  private String logResourceDeletionRecordValue(final Record<?> record) {
+    final ResourceDeletionRecordValue value = (ResourceDeletionRecordValue) record.getValue();
+    return String.format("(Resource key: %d", value.getResourceKey());
   }
 
   protected Map<ValueType, Function<Record<?>, String>> getValueTypeLoggers() {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Adds a logger for the new ResourceDeletion ValueType. This record only contains a resource key.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #443

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
