### PR TITLE
feat: Make `InMemoryEngine` public

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryEngine.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryEngine.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class InMemoryEngine implements ZeebeTestEngine {
+public class InMemoryEngine implements ZeebeTestEngine {
 
   private static final Logger LOG = LoggerFactory.getLogger(InMemoryEngine.class);
 


### PR DESCRIPTION
## Description

Because the constructor of this class and all methods has a public visibility we should make the `InMemoryEngine` public as well to use it in other projects

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #645 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
