### PR TITLE
deps: bump zeebe version to 8.2.0-alpha5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <dependency.slf4j.version>2.0.6</dependency.slf4j.version>
     <dependency.snakeyaml.version>1.33</dependency.snakeyaml.version>
     <dependency.testcontainers.version>1.17.6</dependency.testcontainers.version>
-    <dependency.zeebe.version>8.2.0-SNAPSHOT</dependency.zeebe.version>
+    <dependency.zeebe.version>8.2.0-alpha5</dependency.zeebe.version>
 
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
 


### PR DESCRIPTION
## Description

Set zeebe version to the latest release 8.2.0-alpha5

