### PR TITLE
fix(engine): fix compile issues in Engine creation

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
@@ -9,8 +9,8 @@ package io.camunda.zeebe.process.test.engine;
 
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.Engine;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
-import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributionCommandSender;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamBuilder;
@@ -157,9 +157,9 @@ public class EngineFactory {
                             context,
                             partitionCount,
                             new SubscriptionCommandSender(context.getPartitionId(), commandSender),
-                            new DeploymentDistributionCommandSender(
-                                context.getPartitionId(), commandSender),
-                            FeatureFlags.createDefault()))))
+                            commandSender,
+                            FeatureFlags.createDefault()),
+                    new EngineConfiguration())))
         .actorSchedulingService(scheduler)
         .build();
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Some changes were made in Zeebe. The creation of the processors now requires an InterPartitionCommandSender directly, instead of a deploymentDistributionBehavior.

Besides this it also requires an EngineConfiguration.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
