### PR TITLE
Re-enable disabled test

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
@@ -50,7 +50,6 @@ import java.util.stream.StreamSupport;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -131,7 +130,6 @@ class EngineClientTest {
   }
 
   @Test
-  @Disabled("Test is flaky due to bug, should be re-enabled when fixed - camunda/zeebe#11848")
   void shouldPublishMessage() {
     // given
     zeebeClient


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This test was previously disabled due to a bug. Now that the bug is resolved, we can re-enable it.

This does not need to be backported, because the test was not disabled on the stable branches.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #687 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
