### PR TITLE
Fix Zeebe Snapshot issues

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.Engine;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamBuilder;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
@@ -158,7 +159,8 @@ public class EngineFactory {
                             partitionCount,
                             new SubscriptionCommandSender(context.getPartitionId(), commandSender),
                             commandSender,
-                            FeatureFlags.createDefault()),
+                            FeatureFlags.createDefault(),
+                            JobStreamer.noop()),
                     new EngineConfiguration())))
         .actorSchedulingService(scheduler)
         .build();


### PR DESCRIPTION
## Description

* The `createEngineProcessors` method was changed in Zeebe as part of [Move GatewayStreamer ownership to engine#12067](https://github.com/camunda/zeebe/pull/12067). The JobStreamer parameter was added.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #708  

