### PR TITLE
Bump Zeebe to 8.2.0

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.2.0-alpha5-SNAPSHOT</version>
+    <version>8.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>zeebe-process-test-api</artifactId>
-  <version>8.2.0-alpha5-SNAPSHOT</version>
+  <version>8.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Process Test API</name>

--- a/assertions/pom.xml
+++ b/assertions/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.2.0-alpha5-SNAPSHOT</version>
+    <version>8.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>zeebe-process-test-assertions</artifactId>
-  <version>8.2.0-alpha5-SNAPSHOT</version>
+  <version>8.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Process Test Assertions</name>

--- a/engine-agent/pom.xml
+++ b/engine-agent/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.2.0-alpha5-SNAPSHOT</version>
+    <version>8.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>zeebe-process-test-engine-agent</artifactId>
-  <version>8.2.0-alpha5-SNAPSHOT</version>
+  <version>8.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Process Test Engine Agent</name>

--- a/engine-protocol/pom.xml
+++ b/engine-protocol/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.2.0-alpha5-SNAPSHOT</version>
+    <version>8.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>zeebe-process-test-engine-protocol</artifactId>
-  <version>8.2.0-alpha5-SNAPSHOT</version>
+  <version>8.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Process Test Engine Protocol</name>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.2.0-alpha5-SNAPSHOT</version>
+    <version>8.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>zeebe-process-test-engine</artifactId>
-  <version>8.2.0-alpha5-SNAPSHOT</version>
+  <version>8.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Process Test Engine</name>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.2.0-alpha5-SNAPSHOT</version>
+    <version>8.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zeebe-process-test-examples</artifactId>

--- a/extension-testcontainer/pom.xml
+++ b/extension-testcontainer/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.2.0-alpha5-SNAPSHOT</version>
+    <version>8.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>zeebe-process-test-extension-testcontainer</artifactId>
-  <version>8.2.0-alpha5-SNAPSHOT</version>
+  <version>8.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Process Test Extension Testcontainer</name>

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.2.0-alpha5-SNAPSHOT</version>
+    <version>8.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>zeebe-process-test-extension</artifactId>
-  <version>8.2.0-alpha5-SNAPSHOT</version>
+  <version>8.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Process Test Extension</name>

--- a/filters/pom.xml
+++ b/filters/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.2.0-alpha5-SNAPSHOT</version>
+    <version>8.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>zeebe-process-test-filters</artifactId>
-  <version>8.2.0-alpha5-SNAPSHOT</version>
+  <version>8.2.0-SNAPSHOT</version>
 
   <name>Zeebe Process Test Filters</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <dependency.snakeyaml.version>2.0</dependency.snakeyaml.version>
     <dependency.spring.version>6.0.7</dependency.spring.version>
     <dependency.testcontainers.version>1.18.0</dependency.testcontainers.version>
-    <dependency.zeebe.version>8.2.0-SNAPSHOT</dependency.zeebe.version>
+    <dependency.zeebe.version>8.2.0</dependency.zeebe.version>
 
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.camunda</groupId>
   <artifactId>zeebe-process-test-root</artifactId>
-  <version>8.2.0-alpha5-SNAPSHOT</version>
+  <version>8.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Zeebe Process Test Root</name>
@@ -111,43 +111,43 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-api</artifactId>
-        <version>8.2.0-alpha5-SNAPSHOT</version>
+        <version>8.2.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-assertions</artifactId>
-        <version>8.2.0-alpha5-SNAPSHOT</version>
+        <version>8.2.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-engine</artifactId>
-        <version>8.2.0-alpha5-SNAPSHOT</version>
+        <version>8.2.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-extension</artifactId>
-        <version>8.2.0-alpha5-SNAPSHOT</version>
+        <version>8.2.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-extension-testcontainer</artifactId>
-        <version>8.2.0-alpha5-SNAPSHOT</version>
+        <version>8.2.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-filters</artifactId>
-        <version>8.2.0-alpha5-SNAPSHOT</version>
+        <version>8.2.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-engine-protocol</artifactId>
-        <version>8.2.0-alpha5-SNAPSHOT</version>
+        <version>8.2.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>

--- a/qa/abstracts/pom.xml
+++ b/qa/abstracts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-qa</artifactId>
-    <version>8.2.0-alpha5-SNAPSHOT</version>
+    <version>8.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/qa/embedded/pom.xml
+++ b/qa/embedded/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-qa</artifactId>
-    <version>8.2.0-alpha5-SNAPSHOT</version>
+    <version>8.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zeebe-process-test-qa-embedded</artifactId>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.2.0-alpha5-SNAPSHOT</version>
+    <version>8.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -27,7 +27,7 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-qa-abstracts</artifactId>
-        <version>8.2.0-alpha5-SNAPSHOT</version>
+        <version>8.2.0-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/qa/testcontainers/pom.xml
+++ b/qa/testcontainers/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-qa</artifactId>
-    <version>8.2.0-alpha5-SNAPSHOT</version>
+    <version>8.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zeebe-process-test-qa-testcontainers</artifactId>


### PR DESCRIPTION
## Description

This PR bumps Zeebe to version 8.2.0, and resets the project version from 8.2.0-alpha5-SNAPSHOT to 8.2.0-SNAPSHOT.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
