### PR TITLE
Auto-merge minor/patch version update by dependabot

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -147,3 +147,37 @@ jobs:
           path: ${{ github.event_path }}
           retention-days: 1
 
+  auto-merge:
+    # This workflow will auto merge a PR authored by dependabot[bot]. It runs only on open PRs ready for
+    # review.
+    #
+    # It will merge the PR only if: it is authored by dependabot[bot], is a minor or patch semantic
+    # update, and all CI checks are successful (ignoring the soon-to-be-removed Jenkins check).
+    #
+    # The workflow is divided into multiple sequential jobs to allow giving only minimal permissions to
+    # the GitHub token passed around.
+    #
+    # Once we're using the merge queue feature, I think we can simplify this workflow a lot by relying
+    # on dependabot merging PRs via its commands, as it will always wait for checks to be green before
+    # merging.
+    name: Auto-merge dependabot PRs
+    runs-on: ubuntu-latest
+    needs: [ test-summary ]
+    if: github.repository == 'camunda/zeebe' && github.actor == 'dependabot[bot]'
+    permissions:
+      checks: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+      - id: metadata
+        name: Fetch dependency metadata
+        uses: dependabot/fetch-metadata@v1.3.6
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - id: approve-and-merge
+        name: Approve and merge PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review ${{ github.event.pull_request.number }} --approve -b "bors merge"
+        env:
+          GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"
+


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This step is copy-pasted from the Zeebe repository. It will run when the test-summary step has completed. If it did it means the PR can be merged.

Adding this makes it so once the CI has passed it automatically comments `bors merge` on the PR. This triggers bors to merge the PR. This removes the maintenance effort of manually having to merge the dependabot PRs.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
