### PR TITLE
Support ProcessInstanceBatch records

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbColumnFamily.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbColumnFamily.java
@@ -141,6 +141,14 @@ final class InMemoryDbColumnFamily<
   }
 
   @Override
+  public void whileEqualPrefix(
+      final DbKey keyPrefix,
+      final KeyType startAtKey,
+      final KeyValuePairVisitor<KeyType, ValueType> visitor) {
+    whileEqualPrefix(context, startAtKey, keyPrefix, keyInstance, valueInstance, visitor);
+  }
+
+  @Override
   public void deleteExisting(final KeyType key) {
     ensureInOpenTransaction(
         context,

--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -112,6 +112,7 @@ public class RecordStreamLogger {
     valueTypeLoggers.put(ValueType.RESOURCE_DELETION, this::logResourceDeletionRecordValue);
 
     valueTypeLoggers.put(ValueType.COMMAND_DISTRIBUTION, this::logCommandDistributionRecordValue);
+    valueTypeLoggers.put(ValueType.PROCESS_INSTANCE_BATCH, record -> "");
   }
 
   public void log() {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Fixes the ZPT snapshot tests by adding 2 fixes:

1. Implements the `whileEqualPrefix` method with a `startAtKey`
2. Adds the `ProcessInstanceBatch` value type to the `RecordLogger`

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #745

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
