### PR TITLE
ci(GHA): Migrate set-output to new GHA environment files

### DIFF
--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -115,7 +115,7 @@ jobs:
             echo "branch=stable/${MAJOR_MINOR_VERSION}" >> $GITHUB_OUTPUT
             echo "Branch = stable/${MAJOR_MINOR_VERSION}"
           else
-            echo "branch=stable/${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
+            echo "branch=${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
             echo "Branch = ${{ github.event.repository.default_branch }}"
           fi
 

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -112,10 +112,10 @@ jobs:
           if ! [ -z "${{ github.event.release.tag_name }}" ] && [[ "${{ github.event.release.tag_name }}" != *"alpha"* ]]; then
             MAJOR_MINOR_VERSION=$(echo ${{ github.event.release.tag_name }} | sed -rn 's/^([0-9]+.[0-9]+).[0-9]+.*$/\1/p')
             test -z "${MAJOR_MINOR_VERSION}" && echo "::error::Tag ${{ github.event.release.tag_name }} does not adhere to semantic versioning" && exit 1
-            echo "::set-output name=branch::stable/$MAJOR_MINOR_VERSION"
-            echo "Branch = stable/$MAJOR_MINOR_VERSION"
+            echo "branch=stable/${MAJOR_MINOR_VERSION}" >> $GITHUB_OUTPUT
+            echo "Branch = stable/${MAJOR_MINOR_VERSION}"
           else
-            echo "::set-output name=branch::${{ github.event.repository.default_branch }}"
+            echo "branch=stable/${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
             echo "Branch = ${{ github.event.repository.default_branch }}"
           fi
 


### PR DESCRIPTION
## Description

As `set-output` is deprecated, see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ and will actually get disabled end of May.

## Related issues

https://camunda.slack.com/archives/C01H4NG9XDY/p1683111124388649?thread_ts=1683032927.278609&cid=C01H4NG9XDY

closes #669