### PR TITLE
#771 assert for error thrown

### DIFF
--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/ProcessInstanceAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/ProcessInstanceAssert.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.process.test.filters.StreamFilter;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -602,6 +603,31 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
     assertThat(hasCalledProcess)
         .withFailMessage("No process with id `%s` was called from this process", processId)
         .isTrue();
+    return this;
+  }
+
+  /**
+   * Asserts whether this process has thrown an error for this element
+   *
+   * @param elementId The id of the element that should have thrown error
+   * @return this {@link ProcessInstanceAssert}
+   */
+  public ProcessInstanceAssert hasProcessInstanceThrownError(final String elementId) {
+
+    final long count =
+        StreamFilter.jobRecords(recordStream)
+            .withIntent(JobIntent.ERROR_THROWN)
+            .withElementId(elementId)
+            .stream()
+            .filter(r -> r.getValue().getProcessInstanceKey() == actual)
+            .count();
+
+    assertThat(count)
+        .withFailMessage(
+            "Expected element with id %s to have thrown %s error(s), but was %s",
+            elementId, 1, count)
+        .isEqualTo(1);
+
     return this;
   }
 


### PR DESCRIPTION
## And an assert for exception thrown in Zeebe Process Test

I have added a new assert to ProcessInstanceAssert

## Related issues

Issue #771 will be closed

closes #771 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ X] I've reviewed my own code
* [ X] I've written a clear changelist description
* [ X] I've narrowly scoped my changes
* [ X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ X] The behavior is tested manually

Documentation:
* [ X] Javadoc has been written
* [ ] The documentation is updated
