### PR TITLE
[Backport stable/8.0] Verify processId when extracting called process

### DIFF
--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractProcessInstanceAssertTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractProcessInstanceAssertTest.java
@@ -26,8 +26,10 @@ import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.assertions.IncidentAssert;
 import io.camunda.zeebe.process.test.qa.util.Utilities;
+import io.camunda.zeebe.process.test.qa.util.Utilities.ProcessPackCallActivity;
 import io.camunda.zeebe.process.test.qa.util.Utilities.ProcessPackLoopingServiceTask;
 import io.camunda.zeebe.process.test.qa.util.Utilities.ProcessPackMessageEvent;
+import io.camunda.zeebe.process.test.qa.util.Utilities.ProcessPackMultipleCallActivity;
 import io.camunda.zeebe.process.test.qa.util.Utilities.ProcessPackMultipleTasks;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import java.time.Duration;
@@ -74,6 +76,107 @@ public abstract class AbstractProcessInstanceAssertTest {
 
       // then
       BpmnAssert.assertThat(instanceEvent).isStarted();
+    }
+
+    @Test
+    void testHasCalledProcess() throws InterruptedException, TimeoutException {
+      // given
+      Utilities.deployResources(
+          client,
+          ProcessPackMultipleCallActivity.RESOURCE_NAME,
+          ProcessPackMultipleCallActivity.CALLED_RESOURCE_NAME_ONE,
+          ProcessPackMultipleCallActivity.CALLED_RESOURCE_NAME_TWO,
+          ProcessPackMultipleCallActivity.CALLED_RESOURCE_NAME_THREE);
+
+      // when
+      final ProcessInstanceEvent instanceEvent =
+          Utilities.startProcessInstance(
+              engine, client, ProcessPackMultipleCallActivity.PROCESS_ID);
+
+      // then
+      BpmnAssert.assertThat(instanceEvent)
+          .hasCalledProcess(ProcessPackMultipleCallActivity.CALLED_PROCESS_ID_ONE)
+          .hasCalledProcess(ProcessPackMultipleCallActivity.CALLED_PROCESS_ID_TWO)
+          // Specifically, the process in scope, the parent process, has not made the call to the
+          // child process of the call activity
+          .hasNotCalledProcess(ProcessPackMultipleCallActivity.CALLED_PROCESS_ID_THREE)
+          // The child process however, has called it's own child process.
+          .extractingLatestCalledProcess(ProcessPackMultipleCallActivity.CALLED_PROCESS_ID_TWO)
+          .hasCalledProcess(ProcessPackMultipleCallActivity.CALLED_PROCESS_ID_THREE)
+          // And the nested child process has not called any process.
+          .extractingLatestCalledProcess()
+          .hasNotCalledProcess();
+    }
+
+    @Test
+    void testHasNotCalledProcess() throws InterruptedException, TimeoutException {
+      // given
+      Utilities.deployResources(
+          client,
+          ProcessPackCallActivity.RESOURCE_NAME,
+          ProcessPackCallActivity.CALLED_RESOURCE_NAME);
+
+      // when
+      final ProcessInstanceEvent instanceEvent =
+          Utilities.startProcessInstance(engine, client, ProcessPackCallActivity.PROCESS_ID);
+
+      // then
+      BpmnAssert.assertThat(instanceEvent)
+          .hasCalledProcess(ProcessPackCallActivity.CALLED_PROCESS_ID)
+          .hasNotCalledProcess("NonCalledProcessID")
+          .hasCalledProcess()
+          .extractingLatestCalledProcess()
+          // Specifically, while the parent process has called a process, the called process has
+          // not.
+          .hasNotCalledProcess()
+          .hasNotCalledProcess("NonCalledProcessID");
+    }
+
+    @Test
+    void testExtractingLastCalledSpecificProcess() throws InterruptedException, TimeoutException {
+      // given
+      Utilities.deployResources(
+          client,
+          ProcessPackMultipleCallActivity.RESOURCE_NAME,
+          ProcessPackMultipleCallActivity.CALLED_RESOURCE_NAME_ONE,
+          ProcessPackMultipleCallActivity.CALLED_RESOURCE_NAME_TWO,
+          ProcessPackMultipleCallActivity.CALLED_RESOURCE_NAME_THREE);
+
+      // when
+      final ProcessInstanceEvent instanceEvent =
+          Utilities.startProcessInstance(
+              engine, client, ProcessPackMultipleCallActivity.PROCESS_ID);
+
+      // then
+      // Show the correct process is extracted by checking it's called processes,
+      // as we can't check processId.
+      BpmnAssert.assertThat(instanceEvent)
+          .extractingLatestCalledProcess(ProcessPackMultipleCallActivity.CALLED_PROCESS_ID_TWO)
+          .hasCalledProcess(ProcessPackMultipleCallActivity.CALLED_PROCESS_ID_THREE);
+      BpmnAssert.assertThat(instanceEvent)
+          .extractingLatestCalledProcess(ProcessPackMultipleCallActivity.CALLED_PROCESS_ID_ONE)
+          .hasNotCalledProcess();
+    }
+
+    @Test
+    void testExtractingLastCalledProcess() throws InterruptedException, TimeoutException {
+      // given
+      Utilities.deployResources(
+          client,
+          ProcessPackMultipleCallActivity.RESOURCE_NAME,
+          ProcessPackMultipleCallActivity.CALLED_RESOURCE_NAME_ONE,
+          ProcessPackMultipleCallActivity.CALLED_RESOURCE_NAME_TWO,
+          ProcessPackMultipleCallActivity.CALLED_RESOURCE_NAME_THREE);
+
+      // when
+      final ProcessInstanceEvent instanceEvent =
+          Utilities.startProcessInstance(
+              engine, client, ProcessPackMultipleCallActivity.PROCESS_ID);
+
+      // then
+      // Show the correct process is extracted by checking it's called processes,
+      // as we can't check processId. The last called process has no call activities.
+      BpmnAssert.assertThat(instanceEvent).extractingLatestCalledProcess().hasNotCalledProcess();
     }
 
     @Test
@@ -634,6 +737,162 @@ public abstract class AbstractProcessInstanceAssertTest {
           .isInstanceOf(AssertionError.class)
           .hasMessage(
               "Process with key %s was not terminated", instanceEvent.getProcessInstanceKey());
+    }
+
+    @Test
+    void testHasCalledProcessFailNoProcessCalled() throws InterruptedException, TimeoutException {
+      // given
+      Utilities.deployResources(
+          client,
+          ProcessPackCallActivity.RESOURCE_NAME,
+          ProcessPackCallActivity.CALLED_RESOURCE_NAME);
+
+      // when
+      final ProcessInstanceEvent instanceEvent =
+          Utilities.startProcessInstance(engine, client, ProcessPackCallActivity.PROCESS_ID);
+
+      // then
+      assertThatThrownBy(
+              () ->
+                  BpmnAssert.assertThat(instanceEvent)
+                      .extractingLatestCalledProcess()
+                      .hasCalledProcess())
+          .isInstanceOf(AssertionError.class)
+          .hasMessage("No process was called from this process");
+    }
+
+    @Test
+    void testHasCalledProcessFailSpecificProcessCalled()
+        throws InterruptedException, TimeoutException {
+      // given
+      Utilities.deployResources(
+          client,
+          ProcessPackCallActivity.RESOURCE_NAME,
+          ProcessPackCallActivity.CALLED_RESOURCE_NAME);
+
+      // when
+      final ProcessInstanceEvent instanceEvent =
+          Utilities.startProcessInstance(engine, client, ProcessPackCallActivity.PROCESS_ID);
+
+      // then
+      assertThatThrownBy(
+              () -> BpmnAssert.assertThat(instanceEvent).hasCalledProcess("NonCalledProcessID"))
+          .isInstanceOf(AssertionError.class)
+          .hasMessage("No process with id `NonCalledProcessID` was called from this process");
+    }
+
+    @Test
+    void testHasNotCalledProcessFailSpecificProcess()
+        throws InterruptedException, TimeoutException {
+      // given
+      Utilities.deployResources(
+          client,
+          ProcessPackCallActivity.RESOURCE_NAME,
+          ProcessPackCallActivity.CALLED_RESOURCE_NAME);
+
+      // when
+      final ProcessInstanceEvent instanceEvent =
+          Utilities.startProcessInstance(engine, client, ProcessPackCallActivity.PROCESS_ID);
+
+      // then
+      assertThatThrownBy(
+              () ->
+                  BpmnAssert.assertThat(instanceEvent)
+                      .hasNotCalledProcess(ProcessPackCallActivity.CALLED_PROCESS_ID))
+          .isInstanceOf(AssertionError.class)
+          .hasMessage(
+              "A process with id `%s` was called from this process",
+              ProcessPackCallActivity.CALLED_PROCESS_ID);
+    }
+
+    @Test
+    void testHasNotCalledProcessFailAnyProcess() throws InterruptedException, TimeoutException {
+      // given
+      Utilities.deployResources(
+          client,
+          ProcessPackCallActivity.RESOURCE_NAME,
+          ProcessPackCallActivity.CALLED_RESOURCE_NAME);
+
+      // when
+      final ProcessInstanceEvent instanceEvent =
+          Utilities.startProcessInstance(engine, client, ProcessPackCallActivity.PROCESS_ID);
+
+      // then
+      assertThatThrownBy(() -> BpmnAssert.assertThat(instanceEvent).hasNotCalledProcess())
+          .isInstanceOf(AssertionError.class)
+          .hasMessage(
+              "A process was called from this process, distinct called processes are: [start-end]");
+    }
+
+    @Test
+    void testHasNotCalledProcessFailMultipleProcesses()
+        throws InterruptedException, TimeoutException {
+      // given
+      Utilities.deployResources(
+          client,
+          ProcessPackMultipleCallActivity.RESOURCE_NAME,
+          ProcessPackMultipleCallActivity.CALLED_RESOURCE_NAME_ONE,
+          ProcessPackMultipleCallActivity.CALLED_RESOURCE_NAME_TWO,
+          ProcessPackMultipleCallActivity.CALLED_RESOURCE_NAME_THREE);
+
+      // when
+      final ProcessInstanceEvent instanceEvent =
+          Utilities.startProcessInstance(
+              engine, client, ProcessPackMultipleCallActivity.PROCESS_ID);
+
+      // then
+      assertThatThrownBy(() -> BpmnAssert.assertThat(instanceEvent).hasNotCalledProcess())
+          .isInstanceOf(AssertionError.class)
+          .hasMessage(
+              "A process was called from this process, distinct called processes are: [alternate-start-end, call-activity]");
+    }
+
+    @Test
+    void testExtractingLatestCalledProcessFailAnyProcess()
+        throws InterruptedException, TimeoutException {
+      // given
+      Utilities.deployResources(
+          client,
+          ProcessPackCallActivity.RESOURCE_NAME,
+          ProcessPackCallActivity.CALLED_RESOURCE_NAME);
+
+      // when
+      final ProcessInstanceEvent instanceEvent =
+          Utilities.startProcessInstance(engine, client, ProcessPackCallActivity.PROCESS_ID);
+
+      // then
+      assertThatThrownBy(
+              () ->
+                  BpmnAssert.assertThat(instanceEvent)
+                      // We use a process that has a call activity, to make sure the child process
+                      // doesn't
+                      // extract itself because of a reference to the parent process.
+                      .extractingLatestCalledProcess()
+                      .extractingLatestCalledProcess())
+          .isInstanceOf(AssertionError.class)
+          .hasMessage("No process was called from this process");
+    }
+
+    @Test
+    void testExtractingLatestCalledProcessFailSpecificProcess()
+        throws InterruptedException, TimeoutException {
+      // given
+      Utilities.deployResources(
+          client,
+          ProcessPackCallActivity.RESOURCE_NAME,
+          ProcessPackCallActivity.CALLED_RESOURCE_NAME);
+
+      // when
+      final ProcessInstanceEvent instanceEvent =
+          Utilities.startProcessInstance(engine, client, ProcessPackCallActivity.PROCESS_ID);
+
+      // then
+      assertThatThrownBy(
+              () ->
+                  BpmnAssert.assertThat(instanceEvent)
+                      .extractingLatestCalledProcess("NonCalledProcessId"))
+          .isInstanceOf(AssertionError.class)
+          .hasMessage("No process with id `NonCalledProcessId` was called from this process");
     }
 
     @Test

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/util/Utilities.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/util/Utilities.java
@@ -256,6 +256,21 @@ public class Utilities {
     public static final String TIMER_ID = "timer";
   }
 
+  public static final class ProcessPackMultipleCallActivity {
+
+    public static final String RESOURCE_NAME = "multiple-call-activity.bpmn";
+    public static final String PROCESS_ID = "multiple-call-activity";
+    public static final String CALL_ACTIVITY_ID_ONE = "callactivityOne";
+    public static final String CALLED_RESOURCE_NAME_ONE =
+        ProcessPackAlternateStartEndEvent.RESOURCE_NAME;
+    public static final String CALLED_PROCESS_ID_ONE = ProcessPackAlternateStartEndEvent.PROCESS_ID;
+    public static final String CALL_ACTIVITY_ID_TWO = "callactivityTwo";
+    public static final String CALLED_RESOURCE_NAME_TWO = ProcessPackCallActivity.RESOURCE_NAME;
+    public static final String CALLED_PROCESS_ID_TWO = ProcessPackCallActivity.PROCESS_ID;
+    public static final String CALLED_RESOURCE_NAME_THREE = ProcessPackStartEndEvent.RESOURCE_NAME;
+    public static final String CALLED_PROCESS_ID_THREE = ProcessPackStartEndEvent.PROCESS_ID;
+  }
+
   public static final class ProcessPackCallActivity {
 
     public static final String RESOURCE_NAME = "call-activity.bpmn";
@@ -289,5 +304,11 @@ public class Utilities {
     public static final String AUTOMATED_TESTS_RESOURCE_NAME = "automated-tests.bpmn";
     public static final String AUTOMATED_TESTS_PROCESS_ID = "automatedTestsProcess";
     public static final String AUTOMATED_TESTS_RUN_TESTS = "runTests";
+  }
+
+  public static final class ProcessPackAlternateStartEndEvent {
+
+    public static final String RESOURCE_NAME = "alternate-start-end.bpmn";
+    public static final String PROCESS_ID = "alternate-start-end";
   }
 }

--- a/qa/src/test/resources/alternate-start-end.bpmn
+++ b/qa/src/test/resources/alternate-start-end.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_03pj5sg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.12.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
+  <bpmn:process id="alternate-start-end" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0puuckb</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_0ahcnkn">
+      <bpmn:incoming>Flow_0puuckb</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0puuckb" sourceRef="StartEvent_1" targetRef="Event_0ahcnkn" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="alternate-start-end">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ahcnkn_di" bpmnElement="Event_0ahcnkn">
+        <dc:Bounds x="272" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0puuckb_di" bpmnElement="Flow_0puuckb">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="272" y="97" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/src/test/resources/multiple-call-activity.bpmn
+++ b/qa/src/test/resources/multiple-call-activity.bpmn
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1j49vx1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.12.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
+  <bpmn:process id="multiple-call-activity" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0p4ke7w</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:callActivity id="callactivityOne" name="alternate-start-end">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="alternate-start-end" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0ugmo42</bpmn:incoming>
+      <bpmn:outgoing>Flow_1n2quwf</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_1w612bd">
+      <bpmn:incoming>Flow_1n2quwf</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="callactivityTwo" name="call-activity">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="call-activity" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0p4ke7w</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ugmo42</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_0p4ke7w" sourceRef="StartEvent_1" targetRef="callactivityTwo" />
+    <bpmn:sequenceFlow id="Flow_0ugmo42" sourceRef="callactivityTwo" targetRef="callactivityOne" />
+    <bpmn:sequenceFlow id="Flow_1n2quwf" sourceRef="callactivityOne" targetRef="Event_1w612bd" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="multiple-call-activity">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1tu4rr5" bpmnElement="callactivityTwo">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1w612bd_di" bpmnElement="Event_1w612bd">
+        <dc:Bounds x="632" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1x2fflk_di" bpmnElement="callactivityOne">
+        <dc:Bounds x="450" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0p4ke7w_di" bpmnElement="Flow_0p4ke7w">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ugmo42_di" bpmnElement="Flow_0ugmo42">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="410" y="117" />
+        <di:waypoint x="410" y="120" />
+        <di:waypoint x="450" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1n2quwf_di" bpmnElement="Flow_1n2quwf">
+        <di:waypoint x="550" y="117" />
+        <di:waypoint x="591" y="117" />
+        <di:waypoint x="591" y="120" />
+        <di:waypoint x="632" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Extracting a called process takes a processId. This processId was used to verify the process has called a child process with this specific id. However, upon extracting the processId was ignored. As a result there was no guarantee that the extracted process actually matched the passed processId.

## Related issues

<!-- Which issues are closed by this PR or are related -->

backport of #710