### PR TITLE
Auto-merge releases back to stable branch

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -160,10 +160,10 @@ jobs:
     # Once we're using the merge queue feature, I think we can simplify this workflow a lot by relying
     # on dependabot merging PRs via its commands, as it will always wait for checks to be green before
     # merging.
-    name: Auto-merge dependabot PRs
+    name: Auto-merge dependabot and camundait PRs
     runs-on: ubuntu-latest
     needs: [ test-summary ]
-    if: github.repository == 'camunda/zeebe-process-test' && github.actor == 'dependabot[bot]'
+    if: github.repository == 'camunda/zeebe-process-test' && (github.actor == 'dependabot[bot]' || github.actor == 'camundait')
     permissions:
       checks: read
       pull-requests: write


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Much like what we do for dependabot PRs we can automatically merge back releases to the stable branches as well. Example PR which doesn't get merged automatically now: https://github.com/camunda/zeebe-process-test/pull/835

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #837 
