### PR TITLE
Fix: automerge camundait and backport PRs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -170,6 +170,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: metadata
+        if: github.actor == 'dependabot[bot]'
         name: Fetch dependency metadata
         uses: dependabot/fetch-metadata@v1.6.0
         with:


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The dependabot/fetch-metadata action fails exceptionally if the PR was not created by dependabot. Therefore, we need to add this condition.


## Related issues

<!-- Which issues are closed by this PR or are related -->

N/A

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
