### PR TITLE
refactor(engine): ensure factory fails for snapshot only DB

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbFactory.java
@@ -22,4 +22,9 @@ public class InMemoryDbFactory<ColumnFamilyTpe extends Enum<ColumnFamilyTpe>>
   public ZeebeDb<ColumnFamilyTpe> createDb(final File pathName) {
     return new InMemoryDb<>();
   }
+
+  @Override
+  public ZeebeDb<ColumnFamilyTpe> openSnapshotOnlyDb(final File path) {
+    throw new UnsupportedOperationException("Snapshots are not supported with in-memory databases");
+  }
 }


### PR DESCRIPTION
## Description

This PR fixes a compilation issue, and disables opening so-called "snapshot-only" databases, since snapshots are not supported by in-memory DBs.

## Related issues

closes #866

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
