### PR TITLE
Set current development version to 8.3.0-SNAPSHOT

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.3.0-alpha2-SNAPSHOT</version>
+    <version>8.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>zeebe-process-test-api</artifactId>
-  <version>8.3.0-alpha2-SNAPSHOT</version>
+  <version>8.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Process Test API</name>

--- a/assertions/pom.xml
+++ b/assertions/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.3.0-alpha2-SNAPSHOT</version>
+    <version>8.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>zeebe-process-test-assertions</artifactId>
-  <version>8.3.0-alpha2-SNAPSHOT</version>
+  <version>8.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Process Test Assertions</name>

--- a/engine-agent/pom.xml
+++ b/engine-agent/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.3.0-alpha2-SNAPSHOT</version>
+    <version>8.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>zeebe-process-test-engine-agent</artifactId>
-  <version>8.3.0-alpha2-SNAPSHOT</version>
+  <version>8.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Process Test Engine Agent</name>

--- a/engine-protocol/pom.xml
+++ b/engine-protocol/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.3.0-alpha2-SNAPSHOT</version>
+    <version>8.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>zeebe-process-test-engine-protocol</artifactId>
-  <version>8.3.0-alpha2-SNAPSHOT</version>
+  <version>8.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Process Test Engine Protocol</name>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.3.0-alpha2-SNAPSHOT</version>
+    <version>8.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>zeebe-process-test-engine</artifactId>
-  <version>8.3.0-alpha2-SNAPSHOT</version>
+  <version>8.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Process Test Engine</name>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.3.0-alpha2-SNAPSHOT</version>
+    <version>8.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zeebe-process-test-examples</artifactId>

--- a/extension-testcontainer/pom.xml
+++ b/extension-testcontainer/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.3.0-alpha2-SNAPSHOT</version>
+    <version>8.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>zeebe-process-test-extension-testcontainer</artifactId>
-  <version>8.3.0-alpha2-SNAPSHOT</version>
+  <version>8.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Process Test Extension Testcontainer</name>

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.3.0-alpha2-SNAPSHOT</version>
+    <version>8.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>zeebe-process-test-extension</artifactId>
-  <version>8.3.0-alpha2-SNAPSHOT</version>
+  <version>8.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Process Test Extension</name>

--- a/filters/pom.xml
+++ b/filters/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.3.0-alpha2-SNAPSHOT</version>
+    <version>8.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>zeebe-process-test-filters</artifactId>
-  <version>8.3.0-alpha2-SNAPSHOT</version>
+  <version>8.3.0-SNAPSHOT</version>
 
   <name>Zeebe Process Test Filters</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.camunda</groupId>
   <artifactId>zeebe-process-test-root</artifactId>
-  <version>8.3.0-alpha2-SNAPSHOT</version>
+  <version>8.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Zeebe Process Test Root</name>
@@ -111,43 +111,43 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-api</artifactId>
-        <version>8.3.0-alpha2-SNAPSHOT</version>
+        <version>8.3.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-assertions</artifactId>
-        <version>8.3.0-alpha2-SNAPSHOT</version>
+        <version>8.3.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-engine</artifactId>
-        <version>8.3.0-alpha2-SNAPSHOT</version>
+        <version>8.3.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-extension</artifactId>
-        <version>8.3.0-alpha2-SNAPSHOT</version>
+        <version>8.3.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-extension-testcontainer</artifactId>
-        <version>8.3.0-alpha2-SNAPSHOT</version>
+        <version>8.3.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-filters</artifactId>
-        <version>8.3.0-alpha2-SNAPSHOT</version>
+        <version>8.3.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-engine-protocol</artifactId>
-        <version>8.3.0-alpha2-SNAPSHOT</version>
+        <version>8.3.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>

--- a/qa/abstracts/pom.xml
+++ b/qa/abstracts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-qa</artifactId>
-    <version>8.3.0-alpha2-SNAPSHOT</version>
+    <version>8.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/qa/embedded/pom.xml
+++ b/qa/embedded/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-qa</artifactId>
-    <version>8.3.0-alpha2-SNAPSHOT</version>
+    <version>8.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zeebe-process-test-qa-embedded</artifactId>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.3.0-alpha2-SNAPSHOT</version>
+    <version>8.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -27,7 +27,7 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-qa-abstracts</artifactId>
-        <version>8.3.0-alpha2-SNAPSHOT</version>
+        <version>8.3.0-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/qa/testcontainers/pom.xml
+++ b/qa/testcontainers/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-qa</artifactId>
-    <version>8.3.0-alpha2-SNAPSHOT</version>
+    <version>8.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zeebe-process-test-qa-testcontainers</artifactId>


### PR DESCRIPTION
## Description

To ensure the 8.3.0-SNAPSHOT contains the latest changes, as of now it wasn't updated anymore.

## Related issues

See slack https://camunda.slack.com/archives/C0555930H7F/p1695890722290699?thread_ts=1695883999.551589&cid=C0555930H7F
