### PR TITLE
Set docker image tag to `project.version` by default

### DIFF
--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -60,7 +60,7 @@ jobs:
         # 2. The workflow is triggered by a new release. The tag should be the version of the release.
       - name: Build Docker image
         run: |
-          if ! [ -z "${{ github.event.release.tag_name }}" ] && ! grep -q "$TAG" <<< "SNAPSHOT"; then
+          if ! [ -z "${{ github.event.release.tag_name }}" ]; then
             TAG="${{ github.event.release.tag_name }}"
           else
             TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
@@ -71,7 +71,7 @@ jobs:
         # We push the docker image to dockerhub
       - name: Push Docker image
         run: |
-          if ! [ -z "${{ github.event.release.tag_name }}" ] && ! grep -q "$TAG" <<< "SNAPSHOT"; then
+          if ! [ -z "${{ github.event.release.tag_name }}" ]; then
             TAG="${{ github.event.release.tag_name }}"
           else
             TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -84,18 +84,6 @@ jobs:
           docker tag $IMAGE_NAME:$TAG $IMAGE_ID:$TAG
           docker push $IMAGE_ID:$TAG
 
-        # In extension-testcontainer we have a config file which contains the image tag. This is managed by maven and
-        # maven will set this to the project version upon packaging the application (e.g. 1.4.0, 1.4.0-alpha1, etc.).
-        # In the case this workflow is triggered by a change on the main branch we want this tag to be set to latest.
-        # Maven would set it to a SNAPSHOT version in this case. Therefore, we need to manually set this tag to latest
-        # in this step. This replaces the other value (${project.version}), so it doesn't get replaced by maven anymore.
-      - name: Update tag in config
-        if: github.ref == 'refs/head/main'
-        run: |
-          cd extension-testcontainer/src/main/resources
-          sed -i '/container.image.tag=/ s:=.*:='$TAG':' config.properties
-          cat config.properties
-
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -21,7 +21,6 @@ jobs:
     env:
       OWNER: "camunda"
       IMAGE_NAME: "zeebe-process-test-engine"
-      TAG: "latest"
 
     steps:
       - name: Checkout
@@ -57,12 +56,14 @@ jobs:
           mvn clean package -DskipTests -P !localBuild -pl :zeebe-process-test-engine-agent -am
 
         # We build a docker image with a specific tag. There are 2 possible scenarios here.
-        # 1. The workflow is triggered manually or by a change on the main branch. The tag should be 'latest'.
+        # 1. The workflow is triggered manually or by a change on the main branch. The tag should be equal to the project.version.
         # 2. The workflow is triggered by a new release. The tag should be the version of the release.
       - name: Build Docker image
         run: |
           if ! [ -z "${{ github.event.release.tag_name }}" ] && ! grep -q "$TAG" <<< "SNAPSHOT"; then
             TAG="${{ github.event.release.tag_name }}"
+          else
+            TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           fi
           cd engine-agent
           docker build . -t $IMAGE_NAME:$TAG
@@ -72,6 +73,8 @@ jobs:
         run: |
           if ! [ -z "${{ github.event.release.tag_name }}" ] && ! grep -q "$TAG" <<< "SNAPSHOT"; then
             TAG="${{ github.event.release.tag_name }}"
+          else
+            TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           fi
           echo '${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}' | docker login -u '${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}' --password-stdin
           echo $IMAGE_NAME

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2021 camunda services GmbH (info@camunda.com)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -94,6 +109,7 @@
     <plugin.version.javadoc>3.5.0</plugin.version.javadoc>
     <plugin.version.license>4.2</plugin.version.license>
     <plugin.version.maven-enforcer>3.4.1</plugin.version.maven-enforcer>
+    <plugin.version.maven-help>3.4.0</plugin.version.maven-help>
     <plugin.version.os-maven>1.7.1</plugin.version.os-maven>
     <plugin.version.revapi>0.15.0</plugin.version.revapi>
     <plugin.version.spotless>2.30.0</plugin.version.spotless>
@@ -692,6 +708,12 @@
             <java>SLASHSTAR_STYLE</java>
           </mapping>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-help-plugin</artifactId>
+        <version>${plugin.version.maven-help}</version>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
We should use the project.version when building it from the main branch. If it's triggered via a release the tag should get the tag from the release version.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
