### PR TITLE
Upgrade to java 21

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -111,7 +111,7 @@ jobs:
         id: build
         run: |
           rm .mvn/jvm.config
-          mvn -B -U -pl ":zeebe-process-test-qa-testcontainers" -P !localBuild -am "-Dsurefire.rerunFailingTestsCount=5" install -DskipChecks
+          mvn clean -B -U -pl ":zeebe-process-test-qa-testcontainers" -P !localBuild -am "-Dsurefire.rerunFailingTestsCount=5" install -DskipChecks
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: maven
 
       - name: Check format
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: maven
 
       - name: Build
@@ -78,7 +78,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: maven
 
       - name: Package

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: maven
 
       - name: Build jar

--- a/.github/workflows/snapshot-test.yml
+++ b/.github/workflows/snapshot-test.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Build with Zeebe SNAPSHOT version
         run: |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and provide you with a set of assertions you can use to verify your process beha
 
 ## Prerequisites
 
-* Java 17+ when running with an embedded engine (`zeebe-process-test-extension`)
+* Java 21+ when running with an embedded engine (`zeebe-process-test-extension`)
 * Java 8+ and Docker when running using testcontainers (`zeebe-process-test-extension-testcontainer`)
 * JUnit 5
 
@@ -20,9 +20,9 @@ and provide you with a set of assertions you can use to verify your process beha
 Zeepe Process Test provides you with two dependencies. Which one you need to use is dependent on the
 Java version you are using.
 
-#### Embedded (JDK 17+)
+#### Embedded (JDK 21+)
 
-If you are building your project with JDK 17+ you can make use of an embedded Zeebe test engine. The
+If you are building your project with JDK 21+ you can make use of an embedded Zeebe test engine. The
 advantage of using this instead of the testcontainer version is that this is the faster solution.
 This also does not require Docker to be running. There is also a downside to this solution. The JDK
 requirement is bound to the Java version of the Zeebe engine. Whenever this Java version changes,
@@ -40,7 +40,7 @@ or upgrade your own JDK to match Zeebe engine.
 
 #### Testcontainers (JDK 8+)
 
-If you are building your project with a JDK that's lower than 17 you need to use this dependency. It
+If you are building your project with a JDK that's lower than 21 you need to use this dependency. It
 starts a testcontainer in which a Zeebe test engine is running. The advantage of using this version
 instead of the embedded version is that your code can be implemented independently of the Java
 version that is used by the Zeebe engine. This has some downsides: Testcontainers provide some
@@ -82,7 +82,7 @@ Annotate your test class with the `@ZeebeProcessTest` annotation. This annotatio
 Example:
 
 ```java
-// When using the embedded test engine (Java 17+)
+// When using the embedded test engine (Java 21+)
 import io.camunda.zeebe.process.test.extension.ZeebeProcessTest;
 
 // When using testcontainers (Java 8+)

--- a/engine-agent/Dockerfile
+++ b/engine-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM openjdk:21-alpine
 
 COPY target/*-jar-with-dependencies.jar /zeebe-process-test-engine.jar
 

--- a/engine-agent/Dockerfile
+++ b/engine-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-alpine
+FROM eclipse-temurin:21-jdk-jammy
 
 COPY target/*-jar-with-dependencies.jar /zeebe-process-test-engine.jar
 

--- a/engine-agent/pom.xml
+++ b/engine-agent/pom.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Zeebe Community License 1.1. You may not use this file
+  ~ except in compliance with the Zeebe Community License 1.1.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -126,6 +133,9 @@
             <artifactId>jib-maven-plugin</artifactId>
             <version>3.4.0</version>
             <configuration>
+              <from>
+                <image>eclipse-temurin:21-jdk-jammy</image>
+              </from>
               <to>
                 <image>camunda/zeebe-process-test-engine</image>
                 <tags>${project.version}</tags>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -27,8 +27,8 @@
   <name>Zeebe Process Test Examples</name>
 
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTest.java
+++ b/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * This annotation can be used to test BPMN processes. It will run an in memory Zeebe engine. To use
- * this annotation Java 17 or higher is required.
+ * this annotation Java 21 or higher is required.
  *
  * <p>Annotating test classes with this annotation will do a couple of things:
  *
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *   <li>After each test stop the Zeebe test engine
  * </ul>
  *
- * @since Java 17
+ * @since Java 21
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <skipChecks>false</skipChecks>
 
     <version.grpc>1.58.0</version.grpc>
-    <version.java>17</version.java>
+    <version.java>21</version.java>
     <version.protobuf>3.19.4</version.protobuf>
   </properties>
 

--- a/qa/embedded/pom.xml
+++ b/qa/embedded/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2021 camunda services GmbH (info@camunda.com)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -12,7 +27,7 @@
   <name>Zeebe Process Test QA Embedded</name>
 
   <properties>
-    <version.java>17</version.java>
+    <version.java>21</version.java>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Zeebe recently upgraded to Java 21 (https://github.com/camunda/zeebe/pull/14697).

To remain compatible with Zeebe this project must be upgraded.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #939

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
