### PR TITLE
Note about Java version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and provide you with a set of assertions you can use to verify your process beha
 
 ## Prerequisites
 
-* Java 21+ when running with an embedded engine (`zeebe-process-test-extension`)
+* Java 21+ (17+ for >=`8.3`) when running with an embedded engine (`zeebe-process-test-extension`)
 * Java 8+ and Docker when running using testcontainers (`zeebe-process-test-extension-testcontainer`)
 * JUnit 5
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and provide you with a set of assertions you can use to verify your process beha
 
 ## Prerequisites
 
-* Java 21+ (17+ for >=`8.3`) when running with an embedded engine (`zeebe-process-test-extension`)
+* Java 21+ (17+ for <=`8.3.x`) when running with an embedded engine (`zeebe-process-test-extension`)
 * Java 8+ and Docker when running using testcontainers (`zeebe-process-test-extension-testcontainer`)
 * JUnit 5
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

The main branch readme currently states that Java 21 is required to run embedded process tests.

This can be confusing, as this information applies to 8.4 (alpha) releases, while the common user will use a stable version (8.3)

This PR adds a note that can be removed later.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
