### PR TITLE
Add user task and process instance migration loggers

### DIFF
--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -45,6 +45,7 @@ import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.FormMetadataValue;
@@ -117,6 +118,7 @@ public class RecordStreamLogger {
     valueTypeLoggers.put(ValueType.COMMAND_DISTRIBUTION, this::logCommandDistributionRecordValue);
     valueTypeLoggers.put(ValueType.PROCESS_INSTANCE_BATCH, record -> "");
     valueTypeLoggers.put(ValueType.FORM, this::logFormRecordValue);
+    valueTypeLoggers.put(ValueType.USER_TASK, this::logUserTaskRecordValue);
   }
 
   public void log() {
@@ -438,6 +440,16 @@ public class RecordStreamLogger {
   private String logFormRecordValue(final Record<?> record) {
     final FormMetadataValue value = (FormMetadataValue) record.getValue();
     return String.format("(Form: %s)", value.getResourceName());
+  }
+
+  private String logUserTaskRecordValue(final Record<?> record) {
+    final UserTaskRecordValue value = (UserTaskRecordValue) record.getValue();
+    final StringJoiner joiner = new StringJoiner(", ", "", "");
+    // These fields are empty for commands
+    if (record.getRecordType().equals(RecordType.EVENT)) {
+      joiner.add(String.format("(Element id: %s)", value.getElementId()));
+    }
+    return joiner.toString();
   }
 
   protected Map<ValueType, Function<Record<?>, String>> getValueTypeLoggers() {

--- a/filters/src/test/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLoggerTest.java
+++ b/filters/src/test/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLoggerTest.java
@@ -23,9 +23,12 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceCreationStartInstructionValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceMigrationMappingInstructionValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceMigrationRecordValue;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -181,6 +184,31 @@ class RecordStreamLoggerTest {
                             .withElementId("serviceTask1")
                             .build())
                     .build()),
-            "(Element id: serviceTask1), (Job type: task)"));
+            "(Element id: serviceTask1), (Job type: task)"),
+        Arguments.of(
+            Named.of(
+                "Process instance migration with mapping instructions",
+                ImmutableRecord.builder()
+                    .withRecordType(RecordType.EVENT)
+                    .withValueType(ValueType.PROCESS_INSTANCE_MIGRATION)
+                    .withIntent(ProcessInstanceMigrationIntent.MIGRATED)
+                    .withKey(123)
+                    .withValue(
+                        ImmutableProcessInstanceMigrationRecordValue.builder()
+                            .withProcessInstanceKey(123)
+                            .withTargetProcessDefinitionKey(456)
+                            .addMappingInstruction(
+                                ImmutableProcessInstanceMigrationMappingInstructionValue.builder()
+                                    .withSourceElementId("A")
+                                    .withTargetElementId("A")
+                                    .build())
+                            .addMappingInstruction(
+                                ImmutableProcessInstanceMigrationMappingInstructionValue.builder()
+                                    .withSourceElementId("B")
+                                    .withTargetElementId("C")
+                                    .build())
+                            .build())
+                    .build()),
+            "(Process instance key: 123), (Target process definition key: 456), (Mapping instructions: A -> A, B -> C)"));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency.snakeyaml.version>2.2</dependency.snakeyaml.version>
     <dependency.spring.version>6.0.13</dependency.spring.version>
     <dependency.testcontainers.version>1.19.2</dependency.testcontainers.version>
-    <dependency.zeebe.version>8.3.0</dependency.zeebe.version>
+    <dependency.zeebe.version>8.4.0-SNAPSHOT</dependency.zeebe.version>
 
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
 


### PR DESCRIPTION
## Description

Support the new `USER_TASK` value type introduced in Zeebe with https://github.com/camunda/zeebe/issues/14996.

Also supports the new `PROCESS_INSTANCE_MIGRATION` value type introduced in Zeebe with https://github.com/camunda/zeebe/issues/15106

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #977 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
