### PR TITLE
docs: charset issues on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,28 @@ Optional<FormMetadataValue> latestForm = findLatestFormById("<form id>");
 
 [Examples](examples/README.md)
 
+## Troubleshooting
+
+### The encoding for some characters is not working
+
+If your test fails when being run on a Windows machine, please make sure the test is executed with the charset UTF-8.
+
+For maven, the surefire plugin needs to be configured accordingly:
+
+```xml
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-surefire-plugin</artifactId>
+      <configuration>
+        <argLine>-Dfile.encoding=UTF-8</argLine>
+      </configuration>
+    </plugin>
+  </plugins>
+</build>
+```
+
 ## Engine lifecycle
 
 The lifecycle of the engine will be fully managed by the extension. The lifecycle for both


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

There is a problem with the embedded zeebe process test if the java runtime uses a different charset than utf-8.

The workaround is now documented.

## Related issues

<!-- Which issues are closed by this PR or are related -->
https://jira.camunda.com/browse/SUPPORT-19730

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
