### PR TITLE
Support using process instance migration from the zeebe client

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcResponseMapper.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcResponseMapper.java
@@ -40,6 +40,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FormMetadata;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.MatchedDecisionRule;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.MigrateProcessInstanceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.MigrateProcessInstanceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessMetadata;
@@ -100,6 +102,8 @@ class GrpcResponseMapper {
           Map.entry(UpdateJobRetriesRequest.class, this::createJobUpdateRetriesResponse),
           Map.entry(UpdateJobTimeoutRequest.class, this::createJobUpdateTimeOutResponse),
           Map.entry(ModifyProcessInstanceRequest.class, this::createModifyProcessInstanceResponse),
+          Map.entry(
+              MigrateProcessInstanceRequest.class, this::createMigrateProcessInstanceResponse),
           Map.entry(BroadcastSignalRequest.class, this::createBroadcastSignalResponse));
 
   GeneratedMessageV3 map(
@@ -292,6 +296,10 @@ class GrpcResponseMapper {
 
   private GeneratedMessageV3 createModifyProcessInstanceResponse() {
     return ModifyProcessInstanceResponse.newBuilder().build();
+  }
+
+  private GeneratedMessageV3 createMigrateProcessInstanceResponse() {
+    return MigrateProcessInstanceResponse.getDefaultInstance();
   }
 
   private GeneratedMessageV3 createBroadcastSignalResponse() {

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGatewayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGatewayTest.java
@@ -22,7 +22,16 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class GrpcToLogStreamGatewayTest {
 
-  static final List<String> IGNORED_METHODS = List.of("bindService");
+  static final List<String> IGNORED_METHODS =
+      List.of(
+          "bindService",
+          "equals",
+          "getClass",
+          "hashCode",
+          "notify",
+          "notifyAll",
+          "toString",
+          "wait");
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("provideMethods")
@@ -38,7 +47,7 @@ class GrpcToLogStreamGatewayTest {
   }
 
   static Stream<Arguments> provideMethods() {
-    return Arrays.stream(GatewayImplBase.class.getDeclaredMethods())
+    return Arrays.stream(GatewayImplBase.class.getMethods())
         .map(Method::getName)
         .filter(name -> !IGNORED_METHODS.contains(name))
         .map(Arguments::of);

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGatewayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGatewayTest.java
@@ -44,7 +44,13 @@ class GrpcToLogStreamGatewayTest {
             .findAny();
 
     assertThat(optionalMethod)
-        .describedAs("Expected method %s to be implemented", methodName)
+        .describedAs(
+            """
+            Expected method %s to be implemented. \
+            When this test fails, it's likely a new RPC that ZPT should support. \
+            Please check whether it should be supported by ZPT. \
+            If it should be suported, add a test case to EngineClientTest.java""",
+            methodName)
         .isPresent();
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGatewayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGatewayTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class GrpcToLogStreamGatewayTest {
 
+  static final List<String> UNSUPPORTED_METHODS = List.of("streamActivatedJobs");
+
   static final List<String> IGNORED_METHODS =
       List.of(
           "bindService",
@@ -50,6 +52,7 @@ class GrpcToLogStreamGatewayTest {
     return Arrays.stream(GatewayImplBase.class.getMethods())
         .map(Method::getName)
         .filter(name -> !IGNORED_METHODS.contains(name))
+        .filter(name -> !UNSUPPORTED_METHODS.contains(name))
         .map(Arguments::of);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGatewayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGatewayTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayImplBase;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -20,6 +21,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class GrpcToLogStreamGatewayTest {
+
+  static final List<String> IGNORED_METHODS = List.of("bindService");
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("provideMethods")
@@ -37,7 +40,7 @@ class GrpcToLogStreamGatewayTest {
   static Stream<Arguments> provideMethods() {
     return Arrays.stream(GatewayImplBase.class.getDeclaredMethods())
         .map(Method::getName)
-        .filter(name -> !name.equals("bindService"))
+        .filter(name -> !IGNORED_METHODS.contains(name))
         .map(Arguments::of);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGatewayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGatewayTest.java
@@ -34,9 +34,10 @@ class GrpcToLogStreamGatewayTest {
         .isPresent();
   }
 
-  private static Stream<Arguments> provideMethods() {
+  static Stream<Arguments> provideMethods() {
     return Arrays.stream(GatewayImplBase.class.getDeclaredMethods())
-        .filter(method -> !method.getName().equals("bindService"))
-        .map(method -> Arguments.of(method.getName()));
+        .map(Method::getName)
+        .filter(name -> !name.equals("bindService"))
+        .map(Arguments::of);
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This adds support for the new `MigrateProcessInstance` RPC to ZPT, such that users can try migrating process instances from ZPT. This allows testing migrations before doing so in production.

> [!NOTE]
> This does not add assertions for the migration. That is out of scope.

Additionally, this fixes a test case that no longer added value. The test case was intended to ensure that we don't forget supporting RPCs in ZPT, but the implementation of the test did not function correctly anymore. Now it is able to correctly detect unsupported RPCs again, which [highlighted that `streamActivatedJobs` is not supported by ZPT](https://github.com/camunda/zeebe/issues/11231#issuecomment-1874025863).

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #972

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
