### PR TITLE
Add support for StreamActivatedJobs RPC

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -77,6 +77,21 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-scheduler</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-stream-platform</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-common-protos</artifactId>
     </dependency>
@@ -114,6 +129,11 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
     </dependency>
 
     <!-- Test Scope -->
@@ -186,10 +206,10 @@
               <goal>analyze-duplicate</goal>
             </goals>
             <configuration>
-              <!-- TODO remove this after version of
-              plugin is released which includes
-              https://github.com/apache/maven-dependency-plugin/pull/194 -->
-              <failOnWarning>false</failOnWarning>
+              <ignoredUnusedDeclaredDependencies>
+                <!-- runtime binding for tests -->
+                <dependency>org.slf4j:slf4j-simple</dependency>
+              </ignoredUnusedDeclaredDependencies>
             </configuration>
           </execution>
         </executions>

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcResponseMapper.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcResponseMapper.java
@@ -341,27 +341,26 @@ class GrpcResponseMapper {
     return ActivateJobsResponse.newBuilder()
         .addAllJobs(
             jobsWithKeys.entrySet().stream()
-                .map(
-                    (entry) -> {
-                      final JobRecord job = entry.getValue();
-                      return ActivatedJob.newBuilder()
-                          .setKey(entry.getKey())
-                          .setType(job.getType())
-                          .setRetries(job.getRetries())
-                          .setWorker(job.getWorker())
-                          .setDeadline(job.getDeadline())
-                          .setProcessDefinitionKey(job.getProcessDefinitionKey())
-                          .setBpmnProcessId(job.getBpmnProcessId())
-                          .setProcessDefinitionVersion(job.getProcessDefinitionVersion())
-                          .setProcessInstanceKey(job.getProcessInstanceKey())
-                          .setElementId(job.getElementId())
-                          .setElementInstanceKey(job.getElementInstanceKey())
-                          .setCustomHeaders(
-                              MsgPackConverter.convertToJson(job.getCustomHeadersBuffer()))
-                          .setVariables(MsgPackConverter.convertToJson(job.getVariablesBuffer()))
-                          .build();
-                    })
+                .map((entry) -> mapToActivatedJob(entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList()))
+        .build();
+  }
+
+  static ActivatedJob mapToActivatedJob(final long key, final JobRecord job) {
+    return ActivatedJob.newBuilder()
+        .setKey(key)
+        .setType(job.getType())
+        .setRetries(job.getRetries())
+        .setWorker(job.getWorker())
+        .setDeadline(job.getDeadline())
+        .setProcessDefinitionKey(job.getProcessDefinitionKey())
+        .setBpmnProcessId(job.getBpmnProcessId())
+        .setProcessDefinitionVersion(job.getProcessDefinitionVersion())
+        .setProcessInstanceKey(job.getProcessInstanceKey())
+        .setElementId(job.getElementId())
+        .setElementInstanceKey(job.getElementInstanceKey())
+        .setCustomHeaders(MsgPackConverter.convertToJson(job.getCustomHeadersBuffer()))
+        .setVariables(MsgPackConverter.convertToJson(job.getVariablesBuffer()))
         .build();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryJobStreamer.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryJobStreamer.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+
+package io.camunda.zeebe.process.test.engine;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJob;
+import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.Predicate;
+import org.agrona.DirectBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class InMemoryJobStreamer implements JobStreamer {
+  private static final Logger LOGGER = LoggerFactory.getLogger(InMemoryJobStreamer.class);
+
+  private final ConcurrentMap<DirectBuffer, InMemoryJobStream> streams = new ConcurrentHashMap<>();
+  private final CommandWriter yieldWriter;
+
+  InMemoryJobStreamer(final CommandWriter yieldWriter) {
+    this.yieldWriter = yieldWriter;
+  }
+
+  @Override
+  public Optional<JobStream> streamFor(
+      final DirectBuffer jobType, final Predicate<JobActivationProperties> filter) {
+    return Optional.ofNullable(streams.get(jobType))
+        .flatMap(s -> filter.test(s.properties()) ? Optional.of(s) : Optional.empty());
+  }
+
+  void addStream(
+      final DirectBuffer jobType,
+      final JobActivationProperties properties,
+      final JobConsumer consumer) {
+    streams.compute(
+        jobType,
+        (ignored, s) -> {
+          final var stream =
+              s == null ? new InMemoryJobStream(properties, new CopyOnWriteArraySet<>()) : s;
+          stream.consumers.add(consumer);
+          return stream;
+        });
+  }
+
+  void removeStream(final DirectBuffer jobType, final JobConsumer consumer) {
+    streams.compute(
+        jobType,
+        (ignored, stream) -> {
+          if (stream == null) {
+            return null;
+          }
+
+          stream.consumers.remove(consumer);
+          if (stream.consumers.isEmpty()) {
+            return null;
+          }
+
+          return stream;
+        });
+  }
+
+  private void yieldJob(final ActivatedJob job) {
+    final var metadata =
+        new RecordMetadata()
+            .intent(JobIntent.YIELD)
+            .recordType(RecordType.COMMAND)
+            .valueType(ValueType.JOB);
+    yieldWriter.writeCommandWithKey(job.jobKey(), job.jobRecord(), metadata);
+  }
+
+  interface JobConsumer {
+    CompletionStage<PushStatus> consumeJob(final ActivatedJob job);
+  }
+
+  enum PushStatus {
+    PUSHED,
+    BLOCKED;
+  }
+
+  private final class InMemoryJobStream implements JobStream {
+    private final JobActivationProperties properties;
+    private final Set<JobConsumer> consumers;
+
+    InMemoryJobStream(final JobActivationProperties properties, final Set<JobConsumer> consumers) {
+      this.properties = properties;
+      this.consumers = consumers;
+    }
+
+    @Override
+    public JobActivationProperties properties() {
+      return properties;
+    }
+
+    @Override
+    public void push(final ActivatedJob payload) {
+      final var shuffled = new LinkedList<>(consumers);
+      Collections.shuffle(shuffled);
+      push(shuffled, payload);
+    }
+
+    private void push(final Queue<JobConsumer> consumers, final ActivatedJob job) {
+      final var consumer = consumers.poll();
+      if (consumer == null) {
+        LOGGER.debug("Failed to push job to clients, exhausted all known clients");
+        yieldJob(job);
+        return;
+      }
+
+      try {
+        consumer
+            .consumeJob(job)
+            .whenCompleteAsync(
+                (status, error) -> {
+                  if (error != null) {
+                    onPushError(consumers, job, error);
+                    return;
+                  }
+
+                  if (status == PushStatus.BLOCKED) {
+                    LOGGER.trace(
+                        "Underlying stream or client is blocked, retrying with next consumer");
+                    CompletableFuture.runAsync(() -> push(consumers, job));
+                  }
+                });
+      } catch (final Exception e) {
+        onPushError(consumers, job, e);
+      }
+    }
+
+    private void onPushError(
+        final Queue<JobConsumer> consumers, final ActivatedJob job, final Throwable error) {
+      LOGGER.debug("Failed to push job to client, retrying with next consumer", error);
+      CompletableFuture.runAsync(() -> push(consumers, job));
+    }
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGatewayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGatewayTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class GrpcToLogStreamGatewayTest {
 
-  static final List<String> UNSUPPORTED_METHODS = List.of("streamActivatedJobs");
+  static final List<String> UNSUPPORTED_METHODS = List.of();
 
   static final List<String> IGNORED_METHODS =
       List.of(

--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,18 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>zeebe-scheduler</artifactId>
+        <version>${dependency.zeebe.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-stream-platform</artifactId>
+        <version>${dependency.zeebe.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>zeebe-util</artifactId>
         <version>${dependency.zeebe.version}</version>
       </dependency>


### PR DESCRIPTION
## Description

This PR adds support for the `StreamActivatedJobs` RPC with `zeebe-process-test`, including basic back pressure implementation.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
