### PR TITLE
Timer events fail with specific values

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/Bytes.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/Bytes.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.process.test.engine.db;
 
+import com.google.common.primitives.UnsignedBytes;
 import io.camunda.zeebe.db.DbValue;
 import java.util.Arrays;
 import org.agrona.ExpandableArrayBuffer;
@@ -21,6 +22,11 @@ final class Bytes implements Comparable<Bytes> {
   }
 
   @Override
+  public int hashCode() {
+    return Arrays.hashCode(byteArray);
+  }
+
+  @Override
   public boolean equals(final Object o) {
     if (this == o) {
       return true;
@@ -32,11 +38,6 @@ final class Bytes implements Comparable<Bytes> {
     final Bytes bytes = (Bytes) o;
 
     return Arrays.equals(byteArray, bytes.byteArray);
-  }
-
-  @Override
-  public int hashCode() {
-    return Arrays.hashCode(byteArray);
   }
 
   @Override
@@ -56,9 +57,10 @@ final class Bytes implements Comparable<Bytes> {
       final byte ourByte = byteArray[i];
       final byte otherByte = otherByteArray[i];
 
-      if (ourByte < otherByte) {
+      final int compared = UnsignedBytes.compare(ourByte, otherByte);
+      if (compared < 0) {
         return SMALLER;
-      } else if (ourByte > otherByte) {
+      } else if (compared > 0) {
         return BIGGER;
       } // else { // = equals -> continue }
     }

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/Bytes.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/Bytes.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.process.test.engine.db;
 
-import com.google.common.primitives.UnsignedBytes;
 import io.camunda.zeebe.db.DbValue;
 import java.util.Arrays;
 import org.agrona.ExpandableArrayBuffer;
@@ -42,35 +41,7 @@ final class Bytes implements Comparable<Bytes> {
 
   @Override
   public int compareTo(final Bytes other) {
-
-    final int EQUAL = 0;
-    final int SMALLER = -1;
-    final int BIGGER = 1;
-
-    final byte[] otherByteArray = other.byteArray;
-
-    for (int i = 0; i < byteArray.length; i++) {
-      if (i >= otherByteArray.length) {
-        return BIGGER;
-      }
-
-      final byte ourByte = byteArray[i];
-      final byte otherByte = otherByteArray[i];
-
-      final int compared = UnsignedBytes.compare(ourByte, otherByte);
-      if (compared < 0) {
-        return SMALLER;
-      } else if (compared > 0) {
-        return BIGGER;
-      } // else { // = equals -> continue }
-    }
-
-    if (byteArray.length == otherByteArray.length) {
-      return EQUAL;
-    } else {
-      // the other must be a longer array then
-      return SMALLER;
-    }
+    return Arrays.compareUnsigned(byteArray, other.byteArray);
   }
 
   byte[] toBytes() {

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/BytesTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/BytesTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 public class BytesTest {
 
   @Test
-  public void compareDifferentSizeSmaller() {
+  public void shouldYieldShorterByteArrayAsSmaller() {
     // given
     final byte[] shorterArray = new byte[10];
     final byte[] longerArray = new byte[11];
@@ -32,7 +32,7 @@ public class BytesTest {
   }
 
   @Test
-  public void compareDifferentSizeBigger() {
+  public void shouldYieldLongerByteArrayAsBigger() {
     // given
     final byte[] shorterArray = new byte[10];
     final byte[] longerArray = new byte[11];
@@ -46,7 +46,7 @@ public class BytesTest {
   }
 
   @Test
-  public void compareEqual() {
+  public void shouldCompareEqualArraysAsZero() {
     // given
     final OffsetDateTime date =
         OffsetDateTime.of(2023, 10, 5, 15, 50, 0, 0, ZoneOffset.of("+02:00"));
@@ -72,7 +72,7 @@ public class BytesTest {
   }
 
   @Test
-  public void compareLaterDateWithEarlierDate() {
+  public void shouldCompareLaterDateAsPositiveNumber() {
     // given
     // 2023.10.10 15:50:00 This date will look as follows when converted to bytes array:
     // [0, 0, 1, -117, 25...]
@@ -106,7 +106,7 @@ public class BytesTest {
   }
 
   @Test
-  public void compareEarlierDateWithLaterDate() {
+  public void shouldCompareEarlierDateAsNegativeNumber() {
     // given
     // 2023.10.10 15:50:00 This date will look as follows when converted to bytes array:
     // [0, 0, 1, -117, 25...]

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/BytesTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/BytesTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+
+package io.camunda.zeebe.process.test.engine.db;
+
+import io.camunda.zeebe.db.impl.ZeebeDbConstants;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import org.agrona.ExpandableArrayBuffer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class BytesTest {
+  @Test
+  public void compareEqual() {
+    // given
+    final OffsetDateTime date =
+        OffsetDateTime.of(2023, 10, 5, 15, 50, 0, 0, ZoneOffset.of("+02:00"));
+
+    final OffsetDateTime sameDate =
+        OffsetDateTime.of(2023, 10, 5, 15, 50, 0, 0, ZoneOffset.of("+02:00"));
+
+    final ExpandableArrayBuffer dateKeyBuffer = new ExpandableArrayBuffer();
+    dateKeyBuffer.putLong(0, date.toInstant().toEpochMilli(), ZeebeDbConstants.ZB_DB_BYTE_ORDER);
+
+    final ExpandableArrayBuffer sameDateKeyBuffer = new ExpandableArrayBuffer();
+    sameDateKeyBuffer.putLong(
+        0, sameDate.toInstant().toEpochMilli(), ZeebeDbConstants.ZB_DB_BYTE_ORDER);
+
+    // when
+    final int result = date.compareTo(sameDate);
+
+    // then
+    Assertions.assertEquals(0, result);
+  }
+
+  @Test
+  public void compareLaterDateWithEarlierDate() {
+    // given
+    // 2023.10.10 15:50:00 This date will look as follows when converted to bytes array:
+    // [0, 0, 1, -117, 25...]
+    final OffsetDateTime earlierDate =
+        OffsetDateTime.of(2023, 10, 10, 15, 50, 0, 0, ZoneOffset.of("+02:00"));
+
+    // 2023.11.5 15:50:00 This date will look as follows when converted to bytes array:
+    // [0, 0, 1, -117, -97...]
+    final OffsetDateTime laterDate =
+        OffsetDateTime.of(2023, 11, 5, 15, 50, 0, 0, ZoneOffset.of("+02:00"));
+
+    final ExpandableArrayBuffer earlierDateKeyBuffer = new ExpandableArrayBuffer();
+    earlierDateKeyBuffer.putLong(
+        0, earlierDate.toInstant().toEpochMilli(), ZeebeDbConstants.ZB_DB_BYTE_ORDER);
+
+    final ExpandableArrayBuffer laterDateKeyBuffer = new ExpandableArrayBuffer();
+    laterDateKeyBuffer.putLong(
+        0, laterDate.toInstant().toEpochMilli(), ZeebeDbConstants.ZB_DB_BYTE_ORDER);
+
+    final Bytes erlierDateBytes = Bytes.fromExpandableArrayBuffer(earlierDateKeyBuffer);
+    final Bytes laterDateBytes = Bytes.fromExpandableArrayBuffer(laterDateKeyBuffer);
+
+    System.out.println(Arrays.toString(erlierDateBytes.toBytes()));
+    System.out.println(Arrays.toString(laterDateBytes.toBytes()));
+
+    // when
+    final int result = laterDateBytes.compareTo(erlierDateBytes);
+
+    // then
+    // The result should be positive as 2023.11.5 15:50:00 comes after 2023.10.10 15:50:00
+    // The comparison should return 1 despite the fact that later date contains -97
+    // when represented as bytes array
+    Assertions.assertEquals(1, result);
+  }
+
+  @Test
+  public void compareEarlierDateWithLaterDate() {
+    // given
+    // 2023.10.10 15:50:00 This date will look as follows when converted to bytes array:
+    // [0, 0, 1, -117, 25...]
+    final OffsetDateTime earlierDate =
+        OffsetDateTime.of(2023, 10, 10, 15, 50, 0, 0, ZoneOffset.of("+02:00"));
+
+    // 2023.11.5 15:50:00 This date will look as follows when converted to bytes array:
+    // [0, 0, 1, -117, -97...]
+    final OffsetDateTime laterDate =
+        OffsetDateTime.of(2023, 11, 5, 15, 50, 0, 0, ZoneOffset.of("+02:00"));
+
+    final ExpandableArrayBuffer earlierDateKeyBuffer = new ExpandableArrayBuffer();
+    earlierDateKeyBuffer.putLong(
+        0, earlierDate.toInstant().toEpochMilli(), ZeebeDbConstants.ZB_DB_BYTE_ORDER);
+
+    final ExpandableArrayBuffer laterDateKeyBuffer = new ExpandableArrayBuffer();
+    laterDateKeyBuffer.putLong(
+        0, laterDate.toInstant().toEpochMilli(), ZeebeDbConstants.ZB_DB_BYTE_ORDER);
+
+    final Bytes erlierDateBytes = Bytes.fromExpandableArrayBuffer(earlierDateKeyBuffer);
+    final Bytes laterDateBytes = Bytes.fromExpandableArrayBuffer(laterDateKeyBuffer);
+
+    // when
+    final int result = erlierDateBytes.compareTo(laterDateBytes);
+
+    // then
+    // The result should be negative as 2023.10.10 15:50:00 comes before 2023.11.5 15:50:00
+    // The comparison should return 1 despite the fact that later date contains -97
+    // when represented as bytes array
+    Assertions.assertEquals(-1, result);
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/BytesTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/BytesTest.java
@@ -11,12 +11,40 @@ package io.camunda.zeebe.process.test.engine.db;
 import io.camunda.zeebe.db.impl.ZeebeDbConstants;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.Arrays;
 import org.agrona.ExpandableArrayBuffer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class BytesTest {
+
+  @Test
+  public void compareDifferentSizeSmaller() {
+    // given
+    final byte[] shorterArray = new byte[10];
+    final byte[] longerArray = new byte[11];
+
+    // when
+    final int result =
+        Bytes.fromByteArray(shorterArray).compareTo(Bytes.fromByteArray(longerArray));
+
+    // then
+    Assertions.assertTrue(result < 0);
+  }
+
+  @Test
+  public void compareDifferentSizeBigger() {
+    // given
+    final byte[] shorterArray = new byte[10];
+    final byte[] longerArray = new byte[11];
+
+    // when
+    final int result =
+        Bytes.fromByteArray(longerArray).compareTo(Bytes.fromByteArray(shorterArray));
+
+    // then
+    Assertions.assertTrue(result > 0);
+  }
+
   @Test
   public void compareEqual() {
     // given
@@ -33,8 +61,11 @@ public class BytesTest {
     sameDateKeyBuffer.putLong(
         0, sameDate.toInstant().toEpochMilli(), ZeebeDbConstants.ZB_DB_BYTE_ORDER);
 
+    final Bytes dateBytes = Bytes.fromExpandableArrayBuffer(dateKeyBuffer);
+    final Bytes sameDateBytes = Bytes.fromExpandableArrayBuffer(sameDateKeyBuffer);
+
     // when
-    final int result = date.compareTo(sameDate);
+    final int result = dateBytes.compareTo(sameDateBytes);
 
     // then
     Assertions.assertEquals(0, result);
@@ -64,9 +95,6 @@ public class BytesTest {
     final Bytes erlierDateBytes = Bytes.fromExpandableArrayBuffer(earlierDateKeyBuffer);
     final Bytes laterDateBytes = Bytes.fromExpandableArrayBuffer(laterDateKeyBuffer);
 
-    System.out.println(Arrays.toString(erlierDateBytes.toBytes()));
-    System.out.println(Arrays.toString(laterDateBytes.toBytes()));
-
     // when
     final int result = laterDateBytes.compareTo(erlierDateBytes);
 
@@ -74,7 +102,7 @@ public class BytesTest {
     // The result should be positive as 2023.11.5 15:50:00 comes after 2023.10.10 15:50:00
     // The comparison should return 1 despite the fact that later date contains -97
     // when represented as bytes array
-    Assertions.assertEquals(1, result);
+    Assertions.assertTrue(result > 0);
   }
 
   @Test
@@ -108,6 +136,6 @@ public class BytesTest {
     // The result should be negative as 2023.10.10 15:50:00 comes before 2023.11.5 15:50:00
     // The comparison should return 1 despite the fact that later date contains -97
     // when represented as bytes array
-    Assertions.assertEquals(-1, result);
+    Assertions.assertTrue(result < 0);
   }
 }

--- a/qa/abstracts/pom.xml
+++ b/qa/abstracts/pom.xml
@@ -83,6 +83,11 @@
       <artifactId>junit-jupiter-params</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/jobs/AbstractTimerTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/jobs/AbstractTimerTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright © 2021 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.camunda.zeebe.process.test.qa.abstracts.jobs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
+import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
+import io.camunda.zeebe.process.test.assertions.BpmnAssert;
+import io.camunda.zeebe.process.test.filters.RecordStream;
+import io.camunda.zeebe.process.test.qa.abstracts.util.Utilities;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public abstract class AbstractTimerTest {
+
+  private static final String RESOURCE = "test_timer_events.bpmn";
+  private static final String PROCESS_ID = "Process_Timer_Test_01";
+
+  private ZeebeClient client;
+  private ZeebeTestEngine engine;
+  private RecordStream recordStream;
+
+  @BeforeEach
+  void deployProcesses() {
+    final DeploymentEvent deploymentEvent = Utilities.deployResource(client, RESOURCE);
+    BpmnAssert.assertThat(deploymentEvent).containsProcessesByResourceName(RESOURCE);
+  }
+
+  @Test
+  void testDateContainingNegativeByte() throws Exception {
+
+    final OffsetDateTime darkDay =
+        OffsetDateTime.of(2023, 10, 5, 15, 50, 0, 0, ZoneOffset.of("+02:00"));
+
+    Utilities.increaseTime(engine, Duration.between(OffsetDateTime.now(), darkDay));
+
+    client.newCreateInstanceCommand().bpmnProcessId(PROCESS_ID).latestVersion().send().join();
+
+    final ActivateJobsResponse response = Utilities.activateSingleJob(client, "SimpleLog01");
+    final long key = response.getJobs().get(0).getKey();
+
+    client.newCompleteCommand(key).send().join();
+
+    waitForProcessInstanceCompleted();
+  }
+
+  @Test
+  void testLastDayOfTheMonth() throws Exception {
+    final OffsetDateTime heyDay =
+        OffsetDateTime.of(2023, 10, 31, 0, 0, 0, 0, ZoneOffset.of("+02:00"));
+
+    Utilities.increaseTime(engine, Duration.between(OffsetDateTime.now(), heyDay));
+
+    client.newCreateInstanceCommand().bpmnProcessId(PROCESS_ID).latestVersion().send().join();
+
+    final ActivateJobsResponse response = Utilities.activateSingleJob(client, "SimpleLog01");
+    final long key = response.getJobs().get(0).getKey();
+
+    client.newCompleteCommand(key).send().join();
+
+    waitForProcessInstanceCompleted();
+  }
+
+  @Test
+  void testLastHourOfTheMonth() throws Exception {
+    final OffsetDateTime heyDay =
+        OffsetDateTime.of(2023, 10, 31, 23, 0, 0, 0, ZoneOffset.of("+02:00"));
+
+    Utilities.increaseTime(engine, Duration.between(OffsetDateTime.now(), heyDay));
+
+    client.newCreateInstanceCommand().bpmnProcessId(PROCESS_ID).latestVersion().send().join();
+
+    final ActivateJobsResponse response = Utilities.activateSingleJob(client, "SimpleLog01");
+    final long key = response.getJobs().get(0).getKey();
+
+    client.newCompleteCommand(key).send().join();
+
+    waitForProcessInstanceCompleted();
+  }
+
+  @Test
+  void testLastMinuteOfTheMonth() throws Exception {
+    final OffsetDateTime heyDay =
+        OffsetDateTime.of(2023, 10, 31, 23, 59, 0, 0, ZoneOffset.of("+02:00"));
+
+    Utilities.increaseTime(engine, Duration.between(OffsetDateTime.now(), heyDay));
+
+    client.newCreateInstanceCommand().bpmnProcessId(PROCESS_ID).latestVersion().send().join();
+
+    final ActivateJobsResponse response = Utilities.activateSingleJob(client, "SimpleLog01");
+    final long key = response.getJobs().get(0).getKey();
+
+    client.newCompleteCommand(key).send().join();
+
+    waitForProcessInstanceCompleted();
+  }
+
+  @Test
+  void testLastSecondOfTheMonth() throws Exception {
+    final OffsetDateTime heyDay =
+        OffsetDateTime.of(2023, 10, 31, 23, 59, 59, 0, ZoneOffset.of("+02:00"));
+
+    Utilities.increaseTime(engine, Duration.between(OffsetDateTime.now(), heyDay));
+
+    client.newCreateInstanceCommand().bpmnProcessId(PROCESS_ID).latestVersion().send().join();
+
+    final ActivateJobsResponse response = Utilities.activateSingleJob(client, "SimpleLog01");
+    final long key = response.getJobs().get(0).getKey();
+
+    client.newCompleteCommand(key).send().join();
+
+    waitForProcessInstanceCompleted();
+  }
+
+  @Test
+  void testLastSecondOfTheYear() throws Exception {
+    final OffsetDateTime heyDay =
+        OffsetDateTime.of(2023, 12, 31, 23, 59, 59, 0, ZoneOffset.of("+02:00"));
+
+    Utilities.increaseTime(engine, Duration.between(OffsetDateTime.now(), heyDay));
+
+    client.newCreateInstanceCommand().bpmnProcessId(PROCESS_ID).latestVersion().send().join();
+
+    final ActivateJobsResponse response = Utilities.activateSingleJob(client, "SimpleLog01");
+    final long key = response.getJobs().get(0).getKey();
+
+    client.newCompleteCommand(key).send().join();
+
+    waitForProcessInstanceCompleted();
+  }
+
+  private void waitForProcessInstanceCompleted() {
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              final Optional<Record<ProcessInstanceRecordValue>> processCompleted =
+                  StreamSupport.stream(
+                          RecordStream.of(engine.getRecordStreamSource())
+                              .processInstanceRecords()
+                              .spliterator(),
+                          false)
+                      .filter(r -> r.getValue().getBpmnElementType() == BpmnElementType.PROCESS)
+                      .filter(r -> r.getValue().getBpmnProcessId().equals(PROCESS_ID))
+                      .filter(r -> r.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED)
+                      .findFirst();
+
+              assertThat(processCompleted).isNotEmpty();
+            });
+  }
+}

--- a/qa/abstracts/src/main/resources/test_timer_events.bpmn
+++ b/qa/abstracts/src/main/resources/test_timer_events.bpmn
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0flsp50" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.12.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+  <bpmn:process id="Process_Timer_Test_01" name="Timer Test 01" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Main">
+      <bpmn:outgoing>Flow_0yjny2b</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0yjny2b" sourceRef="StartEvent_Main" targetRef="Gateway_SplitParallel" />
+    <bpmn:parallelGateway id="Gateway_SplitParallel">
+      <bpmn:incoming>Flow_0yjny2b</bpmn:incoming>
+      <bpmn:outgoing>Flow_13nx8ki</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0f4xha0</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_13nx8ki" sourceRef="Gateway_SplitParallel" targetRef="TimerEvent_Wait30d" />
+    <bpmn:sequenceFlow id="Flow_0f4xha0" sourceRef="Gateway_SplitParallel" targetRef="Activity_InvokeDummyWorker" />
+    <bpmn:serviceTask id="Activity_InvokeDummyWorker" name="Log Work">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="SimpleLog01" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0f4xha0</bpmn:incoming>
+      <bpmn:outgoing>Flow_1avqbu0</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1avqbu0" sourceRef="Activity_InvokeDummyWorker" targetRef="TimerEvent_Wait1s" />
+    <bpmn:intermediateCatchEvent id="TimerEvent_Wait1s" name="Wait 1s">
+      <bpmn:incoming>Flow_1avqbu0</bpmn:incoming>
+      <bpmn:outgoing>Flow_0cajt90</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_10j57n3">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1S</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="TimerEvent_Wait30d" name="Wait 30 D">
+      <bpmn:incoming>Flow_13nx8ki</bpmn:incoming>
+      <bpmn:outgoing>Flow_0udkjtd</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1vhwggd">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P30D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_0udkjtd" sourceRef="TimerEvent_Wait30d" targetRef="EndEvent_SlowFlow" />
+    <bpmn:sequenceFlow id="Flow_0cajt90" sourceRef="TimerEvent_Wait1s" targetRef="EndEvent_FastFlow" />
+    <bpmn:endEvent id="EndEvent_FastFlow">
+      <bpmn:incoming>Flow_0cajt90</bpmn:incoming>
+      <bpmn:terminateEventDefinition id="TerminateEventDefinition_1aip36j" />
+    </bpmn:endEvent>
+    <bpmn:endEvent id="EndEvent_SlowFlow">
+      <bpmn:incoming>Flow_0udkjtd</bpmn:incoming>
+      <bpmn:terminateEventDefinition id="TerminateEventDefinition_1ek7ect" />
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_Timer_Test_01">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_Main">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_002rc7z_di" bpmnElement="Gateway_SplitParallel">
+        <dc:Bounds x="265" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1aem1ta_di" bpmnElement="Activity_InvokeDummyWorker">
+        <dc:Bounds x="380" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0igsi80_di" bpmnElement="TimerEvent_Wait1s">
+        <dc:Bounds x="552" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="552" y="142" width="37" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ie1wv2_di" bpmnElement="TimerEvent_Wait30d">
+        <dc:Bounds x="412" y="222" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="407" y="265" width="48" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0yr1y45_di" bpmnElement="EndEvent_FastFlow">
+        <dc:Bounds x="662" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1bifv72_di" bpmnElement="EndEvent_SlowFlow">
+        <dc:Bounds x="552" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0yjny2b_di" bpmnElement="Flow_0yjny2b">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="265" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13nx8ki_di" bpmnElement="Flow_13nx8ki">
+        <di:waypoint x="290" y="142" />
+        <di:waypoint x="290" y="240" />
+        <di:waypoint x="412" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0f4xha0_di" bpmnElement="Flow_0f4xha0">
+        <di:waypoint x="315" y="117" />
+        <di:waypoint x="380" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1avqbu0_di" bpmnElement="Flow_1avqbu0">
+        <di:waypoint x="480" y="117" />
+        <di:waypoint x="552" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0cajt90_di" bpmnElement="Flow_0cajt90">
+        <di:waypoint x="588" y="117" />
+        <di:waypoint x="662" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0udkjtd_di" bpmnElement="Flow_0udkjtd">
+        <di:waypoint x="448" y="240" />
+        <di:waypoint x="552" y="240" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/embedded/src/test/java/io/camunda/zeebe/process/test/qa/embedded/jobs/TimerTest.java
+++ b/qa/embedded/src/test/java/io/camunda/zeebe/process/test/qa/embedded/jobs/TimerTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2021 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.camunda.zeebe.process.test.qa.embedded.jobs;
+
+import io.camunda.zeebe.process.test.extension.ZeebeProcessTest;
+import io.camunda.zeebe.process.test.qa.abstracts.jobs.AbstractTimerTest;
+
+@ZeebeProcessTest
+public class TimerTest extends AbstractTimerTest {}

--- a/qa/testcontainers/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/jobs/TimerTest.java
+++ b/qa/testcontainers/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/jobs/TimerTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2021 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.camunda.zeebe.process.test.qa.testcontainer.jobs;
+
+import io.camunda.zeebe.process.test.extension.testcontainer.ZeebeProcessTest;
+import io.camunda.zeebe.process.test.qa.abstracts.jobs.AbstractTimerTest;
+
+@ZeebeProcessTest
+public class TimerTest extends AbstractTimerTest {}


### PR DESCRIPTION
## Description

Fix for [this bug](https://github.com/camunda/zeebe-process-test/issues/975)

<!-- Please explain the changes you made here. -->

The root cause of this bug was in `Bytes` class `compareTo(final Bytes other)` method.

Before we used to compare byte arrays tin the following way:

```
if (ourByte < otherByte) {
        return SMALLER;
    } else if (ourByte > otherByte) {
        return BIGGER;
    } // else { // = equals -> continue }
```

This was leading to incorrect date comparison as we were comparing signed bytes and sometimes the date that was supposed to come after some other date had a negative byte (ex. -97). 

For example:
`2023.10.10 15:50:00` date will look as follows when converted to bytes array: `[0, 0, 1, -117, 25...]`
`2023.11.5 15:50:00` date will look as follows when converted to bytes array: `[0, 0, 1, -117, -97...]`

When comparing these 2 dates we would previously get `2023.11.5 15:50:00` as a smaller date that would result in `2023.10.10 15:50:00` timer event to not be activated.

The fix:
 I am using Guava `UnsignedBytes.compare(ourByte, otherByte)` method instead as it compares the two specified byte values, treating them as unsigned values between 0 and 255 inclusive. For example, (byte) -127 is considered greater than (byte) 127 because it is seen as having the value of positive 129.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #975

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
