### PR TITLE
[Backport stable/8.1] Unflake tests with published messages

### DIFF
--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractMessageAssertTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractMessageAssertTest.java
@@ -136,7 +136,12 @@ public abstract class AbstractMessageAssertTest {
       // when
       final PublishMessageResponse response =
           Utilities.sendMessage(
-              engine, client, ProcessPackMessageEvent.MESSAGE_NAME, CORRELATION_KEY);
+              engine,
+              client,
+              ProcessPackMessageEvent.MESSAGE_NAME,
+              CORRELATION_KEY,
+              Duration.ofMinutes(1),
+              Collections.emptyMap());
 
       // then
       BpmnAssert.assertThat(response).hasNotExpired();
@@ -273,7 +278,12 @@ public abstract class AbstractMessageAssertTest {
       // when
       final PublishMessageResponse response =
           Utilities.sendMessage(
-              engine, client, ProcessPackMessageEvent.MESSAGE_NAME, CORRELATION_KEY);
+              engine,
+              client,
+              ProcessPackMessageEvent.MESSAGE_NAME,
+              CORRELATION_KEY,
+              Duration.ofMinutes(1),
+              Collections.emptyMap());
 
       // then
       assertThatThrownBy(() -> BpmnAssert.assertThat(response).hasExpired())

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/util/Utilities.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/util/Utilities.java
@@ -124,7 +124,7 @@ public class Utilities {
       final String correlationKey)
       throws InterruptedException, TimeoutException {
     return sendMessage(
-        engine, client, messageName, correlationKey, Duration.ofMinutes(1), Collections.emptyMap());
+        engine, client, messageName, correlationKey, Duration.ZERO, Collections.emptyMap());
   }
 
   public static PublishMessageResponse sendMessage(

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/util/Utilities.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/util/Utilities.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+/** This class contains utility methods for our own tests. */
 public class Utilities {
 
   public static DeploymentEvent deployResource(final ZeebeClient client, final String resource) {
@@ -117,6 +118,23 @@ public class Utilities {
     engine.waitForBusyState(duration);
   }
 
+  /**
+   * Publishes a message with the given name and correlation key. Waits for the engine to be idle
+   * afterward to ensure that the message publication is processed.
+   *
+   * <p>The message is published without a time to live and without variables. If you need to set a
+   * time to live or variables, use {@link #sendMessage(ZeebeTestEngine, ZeebeClient, String,
+   * String, Duration, Map)} instead.
+   *
+   * @param engine the engine to wait for to be idle
+   * @param client the client to use to publish the message
+   * @param messageName the name of the message to publish
+   * @param correlationKey the correlation key of the message to publish
+   * @return the response of the publish message command
+   * @throws InterruptedException if the thread is interrupted while waiting for the engine to be
+   *     idle
+   * @throws TimeoutException if the engine does not become idle within the timeout
+   */
   public static PublishMessageResponse sendMessage(
       final ZeebeTestEngine engine,
       final ZeebeClient client,
@@ -127,6 +145,24 @@ public class Utilities {
         engine, client, messageName, correlationKey, Duration.ZERO, Collections.emptyMap());
   }
 
+  /**
+   * Publishes a message with the given name, correlation key, time to live, and variables. Waits
+   * for the engine to be idle afterward to ensure that the message publication is processed.
+   *
+   * <p>If you do not need to set a time to live or variables, use {@link
+   * #sendMessage(ZeebeTestEngine, ZeebeClient, String, String)} instead.
+   *
+   * @param engine the engine to wait for to be idle
+   * @param client the client to use to publish the message
+   * @param messageName the name of the message to publish
+   * @param correlationKey the correlation key of the message to publish
+   * @param timeToLive the time until the message expires after publication
+   * @param variables the variables to pass along as payload of the message to publish
+   * @return the response of the publish message command
+   * @throws InterruptedException if the thread is interrupted while waiting for the engine to be
+   *     idle
+   * @throws TimeoutException if the engine does not become idle within the timeout
+   */
   public static PublishMessageResponse sendMessage(
       final ZeebeTestEngine engine,
       final ZeebeClient client,


### PR DESCRIPTION
# Description
Backport of #1040 to `stable/8.1`.

relates to #984