### PR TITLE
Fix InMemoryDb on zeebe 8.5.0-SNAPSHOT with changes to column family type

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDb.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDb.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.process.test.engine.db;
 
 import io.camunda.zeebe.db.*;
 import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.protocol.EnumValue;
 import java.io.File;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -28,7 +29,7 @@ import java.util.TreeMap;
  *
  * @param <ColumnFamilyType>
  */
-final class InMemoryDb<ColumnFamilyType extends Enum<ColumnFamilyType>>
+final class InMemoryDb<ColumnFamilyType extends Enum<? extends EnumValue> & EnumValue>
     implements ZeebeDb<ColumnFamilyType> {
 
   private final TreeMap<Bytes, Bytes> database = new TreeMap<>();

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbColumnFamily.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbColumnFamily.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.db.KeyValuePairVisitor;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDbInconsistentException;
+import io.camunda.zeebe.protocol.EnumValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Iterator;
 import java.util.Map;
@@ -25,7 +26,7 @@ import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
 
 final class InMemoryDbColumnFamily<
-        ColumnFamilyNames extends Enum<ColumnFamilyNames>,
+        ColumnFamilyNames extends Enum<? extends EnumValue> & EnumValue,
         KeyType extends DbKey,
         ValueType extends DbValue>
     implements ColumnFamily<KeyType, ValueType> {

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbFactory.java
@@ -9,22 +9,23 @@ package io.camunda.zeebe.process.test.engine.db;
 
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbFactory;
+import io.camunda.zeebe.protocol.EnumValue;
 import java.io.File;
 
-public class InMemoryDbFactory<ColumnFamilyTpe extends Enum<ColumnFamilyTpe>>
-    implements ZeebeDbFactory<ColumnFamilyTpe> {
+public class InMemoryDbFactory<ColumnFamilyType extends Enum<? extends EnumValue> & EnumValue>
+    implements ZeebeDbFactory<ColumnFamilyType> {
 
-  public ZeebeDb<ColumnFamilyTpe> createDb() {
+  public ZeebeDb<ColumnFamilyType> createDb() {
     return createDb(null);
   }
 
   @Override
-  public ZeebeDb<ColumnFamilyTpe> createDb(final File pathName) {
+  public ZeebeDb<ColumnFamilyType> createDb(final File pathName) {
     return new InMemoryDb<>();
   }
 
   @Override
-  public ZeebeDb<ColumnFamilyTpe> openSnapshotOnlyDb(final File path) {
+  public ZeebeDb<ColumnFamilyType> openSnapshotOnlyDb(final File path) {
     throw new UnsupportedOperationException("Snapshots are not supported with in-memory databases");
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/InMemoryZeebeDbTransactionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/InMemoryZeebeDbTransactionTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbTransaction;
 import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.protocol.EnumValue;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -512,10 +513,21 @@ public final class InMemoryZeebeDbTransactionTest {
         });
   }
 
-  private enum ColumnFamilies {
-    DEFAULT, // rocksDB needs a default column family
-    ONE,
-    TWO,
-    THREE
+  private enum ColumnFamilies implements EnumValue {
+    DEFAULT(0), // rocksDB needs a default column family
+    ONE(1),
+    TWO(2),
+    THREE(3);
+
+    private final int value;
+
+    ColumnFamilies(final int value) {
+      this.value = value;
+    }
+
+    @Override
+    public int getValue() {
+      return value;
+    }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency.snakeyaml.version>2.2</dependency.snakeyaml.version>
     <dependency.spring.version>6.1.3</dependency.spring.version>
     <dependency.testcontainers.version>1.19.4</dependency.testcontainers.version>
-    <dependency.zeebe.version>8.4.0</dependency.zeebe.version>
+    <dependency.zeebe.version>8.5.0-SNAPSHOT</dependency.zeebe.version>
 
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

The EnumValue is an interface that allows an enum to provide a getValue method that provides a number associated to each enum value. Hardcoding these values is less error prone than using the ordinal.

This was added to zeebe to avoid accidental reordering of column family values.

See:
- https://github.com/camunda/zeebe/pull/16106    

This also updates to 8.5.0-SNAPSHOT of Zeebe, which main should point at anyways.

## Related issues

<!-- Which issues are closed by this PR or are related -->

https://github.com/camunda/zeebe-process-test/actions/runs/7720583417/job/21045722630

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
