### PR TITLE
fix: Add `fetchVariable` parameter support in ActivateJobs RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and provide you with a set of assertions you can use to verify your process beha
 
 ### Dependency
 
-Zeepe Process Test provides you with two dependencies. Which one you need to use is dependent on the
+Zeebe Process Test provides you with two dependencies. Which one you need to use is dependent on the
 Java version you are using.
 
 #### Embedded (JDK 21+)

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGateway.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGateway.java
@@ -102,6 +102,7 @@ import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
@@ -151,6 +152,7 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
     jobBatchRecord.setWorker(request.getWorker());
     jobBatchRecord.setTimeout(request.getTimeout());
     jobBatchRecord.setMaxJobsToActivate(request.getMaxJobsToActivate());
+    setJobBatchRecordVariables(jobBatchRecord, request.getFetchVariableList());
 
     writer.writeCommandWithoutKey(jobBatchRecord, recordMetadata);
   }
@@ -599,6 +601,14 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
             .requestId(requestId)
             .valueType(ValueType.SIGNAL)
             .intent(SignalIntent.BROADCAST));
+  }
+
+  private void setJobBatchRecordVariables(
+      final JobBatchRecord jobBatchRecord, final List<String> fetchVariables) {
+    final ValueArray<StringValue> variables = jobBatchRecord.variables();
+    fetchVariables.stream()
+        .map(BufferUtil::wrapString)
+        .forEach(buffer -> variables.add().wrap(buffer));
   }
 
   private ProcessInstanceModificationRecord createProcessInstanceModificationRecord(


### PR DESCRIPTION
## Description

Enhanced the `activateJobs` method in the `GrpcToLogStreamGateway` class to support the `fetchVariable` parameter. 
This addition allows clients to specify which variables should be fetched when activating jobs. 
The change also includes a new test to verify that only the specified variables are returned on job activation.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #675 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
