### PR TITLE
[Backport stable/8.4] fix: Add `fetchVariable` parameter support in ActivateJobs RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and provide you with a set of assertions you can use to verify your process beha
 
 ### Dependency
 
-Zeepe Process Test provides you with two dependencies. Which one you need to use is dependent on the
+Zeebe Process Test provides you with two dependencies. Which one you need to use is dependent on the
 Java version you are using.
 
 #### Embedded (JDK 21+)

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGateway.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGateway.java
@@ -102,6 +102,7 @@ import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
@@ -151,6 +152,7 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
     jobBatchRecord.setWorker(request.getWorker());
     jobBatchRecord.setTimeout(request.getTimeout());
     jobBatchRecord.setMaxJobsToActivate(request.getMaxJobsToActivate());
+    setJobBatchRecordVariables(jobBatchRecord, request.getFetchVariableList());
 
     writer.writeCommandWithoutKey(jobBatchRecord, recordMetadata);
   }
@@ -599,6 +601,14 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
             .requestId(requestId)
             .valueType(ValueType.SIGNAL)
             .intent(SignalIntent.BROADCAST));
+  }
+
+  private void setJobBatchRecordVariables(
+      final JobBatchRecord jobBatchRecord, final List<String> fetchVariables) {
+    final ValueArray<StringValue> variables = jobBatchRecord.variables();
+    fetchVariables.stream()
+        .map(BufferUtil::wrapString)
+        .forEach(buffer -> variables.add().wrap(buffer));
   }
 
   private ProcessInstanceModificationRecord createProcessInstanceModificationRecord(


### PR DESCRIPTION
# Description
Backport of #1058 to `stable/8.4`.

relates to #675