### PR TITLE
[Backport stable/8.2] fix: Add fetchVariable parameter support in ActivateJobs RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and provide you with a set of assertions you can use to verify your process beha
 
 ### Dependency
 
-Zeepe Process Test provides you with two dependencies. Which one you need to use is dependent on the
+Zeebe Process Test provides you with two dependencies. Which one you need to use is dependent on the
 Java version you are using.
 
 #### Embedded (JDK 17+)

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
@@ -838,6 +838,58 @@ class EngineClientTest {
   }
 
   @Test
+  void shouldReturnOnlySpecifiedVariablesOnJobActivation() {
+    // given
+    zeebeClient
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess("simpleProcess")
+                .startEvent()
+                .serviceTask("task", (task) -> task.zeebeJobType("jobType"))
+                .endEvent()
+                .done(),
+            "simpleProcess.bpmn")
+        .send()
+        .join();
+
+    zeebeClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId("simpleProcess")
+        .latestVersion()
+        .variables(
+            Map.ofEntries(
+                Map.entry("var_a", "val_a"),
+                Map.entry("var_b", "val_b"),
+                Map.entry("var_c", "val_c"),
+                Map.entry("var_d", "val_d")))
+        .send()
+        .join();
+
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              // when
+              final ActivateJobsResponse activateJobsResponse =
+                  zeebeClient
+                      .newActivateJobsCommand()
+                      .jobType("jobType")
+                      .maxJobsToActivate(32)
+                      .timeout(Duration.ofMinutes(1))
+                      .workerName("yolo")
+                      .fetchVariables(List.of("var_b", "var_d"))
+                      .send()
+                      .join();
+
+              // then
+              final List<ActivatedJob> jobs = activateJobsResponse.getJobs();
+              assertThat(jobs)
+                  .first()
+                  .extracting(ActivatedJob::getVariablesAsMap)
+                  .isEqualTo(Map.of("var_b", "val_b", "var_d", "val_d"));
+            });
+  }
+
+  @Test
   void shouldReadProcessInstanceRecords() {
     // given
     zeebeClient


### PR DESCRIPTION
# Description
Backport of #1058 to `stable/8.2`.

relates to #675