### PR TITLE
[Backport stable/8.1] fix: Add fetchVariable parameter support in ActivateJobs RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and provide you with a set of assertions you can use to verify your process beha
 
 ### Dependency
 
-Zeepe Process Test provides you with two dependencies. Which one you need to use is dependent on the
+Zeebe Process Test provides you with two dependencies. Which one you need to use is dependent on the
 Java version you are using.
 
 #### Embedded (JDK 17+)

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGateway.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGateway.java
@@ -41,6 +41,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TopologyRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TopologyResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesResponse;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
@@ -73,6 +74,7 @@ import io.camunda.zeebe.protocol.record.value.VariableDocumentUpdateSemantic;
 import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.grpc.stub.StreamObserver;
+import java.util.List;
 
 class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
 
@@ -114,6 +116,7 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
     jobBatchRecord.setWorker(request.getWorker());
     jobBatchRecord.setTimeout(request.getTimeout());
     jobBatchRecord.setMaxJobsToActivate(request.getMaxJobsToActivate());
+    setJobBatchRecordVariables(jobBatchRecord, request.getFetchVariableList());
 
     writer.writeCommandWithoutKey(jobBatchRecord, recordMetadata);
   }
@@ -439,6 +442,14 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
         createProcessInstanceModificationRecord(request);
 
     writer.writeCommandWithKey(request.getProcessInstanceKey(), record, recordMetadata);
+  }
+
+  private void setJobBatchRecordVariables(
+      final JobBatchRecord jobBatchRecord, final List<String> fetchVariables) {
+    final ValueArray<StringValue> variables = jobBatchRecord.variables();
+    fetchVariables.stream()
+        .map(BufferUtil::wrapString)
+        .forEach(buffer -> variables.add().wrap(buffer));
   }
 
   private ProcessInstanceModificationRecord createProcessInstanceModificationRecord(

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
@@ -768,6 +768,58 @@ class EngineClientTest {
   }
 
   @Test
+  void shouldReturnOnlySpecifiedVariablesOnJobActivation() {
+    // given
+    zeebeClient
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess("simpleProcess")
+                .startEvent()
+                .serviceTask("task", (task) -> task.zeebeJobType("jobType"))
+                .endEvent()
+                .done(),
+            "simpleProcess.bpmn")
+        .send()
+        .join();
+
+    zeebeClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId("simpleProcess")
+        .latestVersion()
+        .variables(
+            Map.ofEntries(
+                Map.entry("var_a", "val_a"),
+                Map.entry("var_b", "val_b"),
+                Map.entry("var_c", "val_c"),
+                Map.entry("var_d", "val_d")))
+        .send()
+        .join();
+
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              // when
+              final ActivateJobsResponse activateJobsResponse =
+                  zeebeClient
+                      .newActivateJobsCommand()
+                      .jobType("jobType")
+                      .maxJobsToActivate(32)
+                      .timeout(Duration.ofMinutes(1))
+                      .workerName("yolo")
+                      .fetchVariables(List.of("var_b", "var_d"))
+                      .send()
+                      .join();
+
+              // then
+              final List<ActivatedJob> jobs = activateJobsResponse.getJobs();
+              assertThat(jobs)
+                  .first()
+                  .extracting(ActivatedJob::getVariablesAsMap)
+                  .isEqualTo(Map.of("var_b", "val_b", "var_d", "val_d"));
+            });
+  }
+
+  @Test
   void shouldReadProcessInstanceRecords() {
     // given
     zeebeClient


### PR DESCRIPTION
# Description
Backport of #1058 to `stable/8.1`.

relates to #675