### PR TITLE
fix: Set variables from ThrowError command

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGateway.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGateway.java
@@ -371,6 +371,11 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
     jobRecord.setErrorCode(BufferUtil.wrapString(request.getErrorCode()));
     jobRecord.setErrorMessage(request.getErrorMessage());
 
+    final String variables = request.getVariables();
+    if (!variables.isEmpty()) {
+      jobRecord.setVariables(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(variables)));
+    }
+
     writer.writeCommandWithKey(request.getJobKey(), jobRecord, recordMetadata);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGateway.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGateway.java
@@ -214,7 +214,7 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
 
     final String variables = request.getVariables();
     if (!variables.isEmpty()) {
-      jobRecord.setVariables(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(variables)));
+      jobRecord.setVariables(convertVariablesToMessagePack(variables));
     }
 
     writer.writeCommandWithKey(request.getJobKey(), jobRecord, recordMetadata);
@@ -373,7 +373,7 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
 
     final String variables = request.getVariables();
     if (!variables.isEmpty()) {
-      jobRecord.setVariables(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(variables)));
+      jobRecord.setVariables(convertVariablesToMessagePack(variables));
     }
 
     writer.writeCommandWithKey(request.getJobKey(), jobRecord, recordMetadata);
@@ -400,8 +400,7 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
     messageRecord.setTimeToLive(request.getTimeToLive());
     final String variables = request.getVariables();
     if (!variables.isEmpty()) {
-      messageRecord.setVariables(
-          BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(variables)));
+      messageRecord.setVariables(convertVariablesToMessagePack(variables));
     }
 
     writer.writeCommandWithoutKey(messageRecord, recordMetadata);
@@ -442,8 +441,7 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
 
     final String variables = request.getVariables();
     if (!variables.isEmpty()) {
-      variableDocumentRecord.setVariables(
-          BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(variables)));
+      variableDocumentRecord.setVariables(convertVariablesToMessagePack(variables));
     }
 
     variableDocumentRecord.setScopeKey(request.getElementInstanceKey());
@@ -596,8 +594,7 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
     final SignalRecord command = new SignalRecord().setSignalName(request.getSignalName());
 
     if (!request.getVariables().isEmpty()) {
-      command.setVariables(
-          BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(request.getVariables())));
+      command.setVariables(convertVariablesToMessagePack(request.getVariables()));
     }
 
     writer.writeCommandWithoutKey(
@@ -629,9 +626,7 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
         instruction.addVariableInstruction(
             new ProcessInstanceModificationVariableInstruction()
                 .setElementId(variable.getScopeId())
-                .setVariables(
-                    BufferUtil.wrapArray(
-                        MsgPackConverter.convertToMsgPack(variable.getVariables()))));
+                .setVariables(convertVariablesToMessagePack(variable.getVariables())));
       }
 
       record.addActivateInstruction(instruction);
@@ -668,8 +663,7 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
 
     final String variables = request.getVariables();
     if (!variables.isEmpty()) {
-      processInstanceCreationRecord.setVariables(
-          BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(variables)));
+      processInstanceCreationRecord.setVariables(convertVariablesToMessagePack(variables));
     }
     return processInstanceCreationRecord;
   }
@@ -686,10 +680,14 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
 
     final String variables = request.getVariables();
     if (!variables.isEmpty()) {
-      record.setVariables(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(variables)));
+      record.setVariables(convertVariablesToMessagePack(variables));
     }
 
     return record;
+  }
+
+  private static DirectBuffer convertVariablesToMessagePack(final String variables) {
+    return BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(variables));
   }
 
   public String getAddress() {

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
@@ -783,10 +783,10 @@ class EngineClientTest {
         .newCreateInstanceCommand()
         .bpmnProcessId("simpleProcess")
         .latestVersion()
-        .variables(Map.of("test", 1))
         .send()
         .join();
 
+    // when
     Awaitility.await()
         .untilAsserted(
             () -> {
@@ -797,7 +797,6 @@ class EngineClientTest {
                       .maxJobsToActivate(32)
                       .timeout(Duration.ofMinutes(1))
                       .workerName("yolo")
-                      .fetchVariables(List.of("test"))
                       .send()
                       .join();
 
@@ -805,7 +804,6 @@ class EngineClientTest {
               assertThat(jobs).isNotEmpty();
               final ActivatedJob job = jobs.get(0);
 
-              // when - then
               zeebeClient
                   .newThrowErrorCommand(job.getKey())
                   .errorCode("0xCAFE")
@@ -813,44 +811,43 @@ class EngineClientTest {
                   .variable("error_var", "Out of coffee")
                   .send()
                   .join();
+            });
 
-              Awaitility.await()
-                  .untilAsserted(
-                      () -> {
-                        final Optional<Record<ProcessInstanceRecordValue>> boundaryEvent =
-                            StreamSupport.stream(
-                                    RecordStream.of(zeebeEngine.getRecordStreamSource())
-                                        .processInstanceRecords()
-                                        .spliterator(),
-                                    false)
-                                .filter(
-                                    r -> r.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED)
-                                .filter(
-                                    r ->
-                                        r.getValue().getBpmnElementType()
-                                            == BpmnElementType.BOUNDARY_EVENT)
-                                .filter(r -> r.getValue().getBpmnEventType() == BpmnEventType.ERROR)
-                                .findFirst();
+    // then
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              final Optional<Record<ProcessInstanceRecordValue>> boundaryEvent =
+                  StreamSupport.stream(
+                          RecordStream.of(zeebeEngine.getRecordStreamSource())
+                              .processInstanceRecords()
+                              .spliterator(),
+                          false)
+                      .filter(r -> r.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED)
+                      .filter(
+                          r -> r.getValue().getBpmnElementType() == BpmnElementType.BOUNDARY_EVENT)
+                      .filter(r -> r.getValue().getBpmnEventType() == BpmnEventType.ERROR)
+                      .findFirst();
 
-                        assertThat(boundaryEvent).isNotEmpty();
+              assertThat(boundaryEvent)
+                  .describedAs("Expect that the error boundary event is completed")
+                  .isNotEmpty();
 
-                        final var errorVariable =
-                            StreamSupport.stream(
-                                    RecordStream.of(zeebeEngine.getRecordStreamSource())
-                                        .variableRecords()
-                                        .spliterator(),
-                                    false)
-                                .filter(r -> r.getValue().getName().equals("error_var"))
-                                .findFirst();
+              final var errorVariable =
+                  StreamSupport.stream(
+                          RecordStream.of(zeebeEngine.getRecordStreamSource())
+                              .variableRecords()
+                              .spliterator(),
+                          false)
+                      .filter(r -> r.getValue().getName().equals("error_var"))
+                      .findFirst();
 
-                        assertThat(errorVariable)
-                            .describedAs("Expect that the error variable is set")
-                            .isPresent()
-                            .hasValueSatisfying(
-                                record ->
-                                    assertThat(record.getValue().getValue())
-                                        .isEqualTo("\"Out of coffee\""));
-                      });
+              assertThat(errorVariable)
+                  .describedAs("Expect that the error variable is set")
+                  .isPresent()
+                  .hasValueSatisfying(
+                      record ->
+                          assertThat(record.getValue().getValue()).isEqualTo("\"Out of coffee\""));
             });
   }
 


### PR DESCRIPTION
## Description

Adjust the handling of the ThrowError gRPC command to set the variables from the command to the job record. As a result, the variables are set as local variables of the error catch event.

## Related issues

closes #1079 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
