### PR TITLE
[Backport stable/8.2] fix: Set variables from ThrowError command

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGateway.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGateway.java
@@ -327,6 +327,11 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
     jobRecord.setErrorCode(BufferUtil.wrapString(request.getErrorCode()));
     jobRecord.setErrorMessage(request.getErrorMessage());
 
+    final String variables = request.getVariables();
+    if (!variables.isEmpty()) {
+      jobRecord.setVariables(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(variables)));
+    }
+
     writer.writeCommandWithKey(request.getJobKey(), jobRecord, recordMetadata);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGateway.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGateway.java
@@ -87,6 +87,7 @@ import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.grpc.stub.StreamObserver;
 import java.util.List;
+import org.agrona.DirectBuffer;
 
 class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
 

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGateway.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGateway.java
@@ -170,7 +170,7 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
 
     final String variables = request.getVariables();
     if (!variables.isEmpty()) {
-      jobRecord.setVariables(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(variables)));
+      jobRecord.setVariables(convertVariablesToMessagePack(variables));
     }
 
     writer.writeCommandWithKey(request.getJobKey(), jobRecord, recordMetadata);
@@ -329,7 +329,7 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
 
     final String variables = request.getVariables();
     if (!variables.isEmpty()) {
-      jobRecord.setVariables(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(variables)));
+      jobRecord.setVariables(convertVariablesToMessagePack(variables));
     }
 
     writer.writeCommandWithKey(request.getJobKey(), jobRecord, recordMetadata);
@@ -356,8 +356,7 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
     messageRecord.setTimeToLive(request.getTimeToLive());
     final String variables = request.getVariables();
     if (!variables.isEmpty()) {
-      messageRecord.setVariables(
-          BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(variables)));
+      messageRecord.setVariables(convertVariablesToMessagePack(variables));
     }
 
     writer.writeCommandWithoutKey(messageRecord, recordMetadata);
@@ -398,8 +397,7 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
 
     final String variables = request.getVariables();
     if (!variables.isEmpty()) {
-      variableDocumentRecord.setVariables(
-          BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(variables)));
+      variableDocumentRecord.setVariables(convertVariablesToMessagePack(variables));
     }
 
     variableDocumentRecord.setScopeKey(request.getElementInstanceKey());
@@ -504,8 +502,7 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
     final SignalRecord command = new SignalRecord().setSignalName(request.getSignalName());
 
     if (!request.getVariables().isEmpty()) {
-      command.setVariables(
-          BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(request.getVariables())));
+      command.setVariables(convertVariablesToMessagePack(request.getVariables()));
     }
 
     writer.writeCommandWithoutKey(
@@ -537,9 +534,7 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
         instruction.addVariableInstruction(
             new ProcessInstanceModificationVariableInstruction()
                 .setElementId(variable.getScopeId())
-                .setVariables(
-                    BufferUtil.wrapArray(
-                        MsgPackConverter.convertToMsgPack(variable.getVariables()))));
+                .setVariables(convertVariablesToMessagePack(variable.getVariables())));
       }
 
       record.addActivateInstruction(instruction);
@@ -576,8 +571,7 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
 
     final String variables = request.getVariables();
     if (!variables.isEmpty()) {
-      processInstanceCreationRecord.setVariables(
-          BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(variables)));
+      processInstanceCreationRecord.setVariables(convertVariablesToMessagePack(variables));
     }
     return processInstanceCreationRecord;
   }
@@ -594,10 +588,14 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
 
     final String variables = request.getVariables();
     if (!variables.isEmpty()) {
-      record.setVariables(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(variables)));
+      record.setVariables(convertVariablesToMessagePack(variables));
     }
 
     return record;
+  }
+
+  private static DirectBuffer convertVariablesToMessagePack(final String variables) {
+    return BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(variables));
   }
 
   public String getAddress() {

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
@@ -749,7 +749,7 @@ class EngineClientTest {
                   .newThrowErrorCommand(job.getKey())
                   .errorCode("0xCAFE")
                   .errorMessage("What just happened.")
-                  .variable("error_var", "Out of coffee")
+                  .variables(Map.of("error_var", "Out of coffee"))
                   .send()
                   .join();
             });

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
@@ -724,10 +724,10 @@ class EngineClientTest {
         .newCreateInstanceCommand()
         .bpmnProcessId("simpleProcess")
         .latestVersion()
-        .variables(Map.of("test", 1))
         .send()
         .join();
 
+    // when
     Awaitility.await()
         .untilAsserted(
             () -> {
@@ -738,7 +738,6 @@ class EngineClientTest {
                       .maxJobsToActivate(32)
                       .timeout(Duration.ofMinutes(1))
                       .workerName("yolo")
-                      .fetchVariables(List.of("test"))
                       .send()
                       .join();
 
@@ -746,7 +745,6 @@ class EngineClientTest {
               assertThat(jobs).isNotEmpty();
               final ActivatedJob job = jobs.get(0);
 
-              // when - then
               zeebeClient
                   .newThrowErrorCommand(job.getKey())
                   .errorCode("0xCAFE")
@@ -754,44 +752,43 @@ class EngineClientTest {
                   .variable("error_var", "Out of coffee")
                   .send()
                   .join();
+            });
 
-              Awaitility.await()
-                  .untilAsserted(
-                      () -> {
-                        final Optional<Record<ProcessInstanceRecordValue>> boundaryEvent =
-                            StreamSupport.stream(
-                                    RecordStream.of(zeebeEngine.getRecordStreamSource())
-                                        .processInstanceRecords()
-                                        .spliterator(),
-                                    false)
-                                .filter(
-                                    r -> r.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED)
-                                .filter(
-                                    r ->
-                                        r.getValue().getBpmnElementType()
-                                            == BpmnElementType.BOUNDARY_EVENT)
-                                .filter(r -> r.getValue().getBpmnEventType() == BpmnEventType.ERROR)
-                                .findFirst();
+    // then
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              final Optional<Record<ProcessInstanceRecordValue>> boundaryEvent =
+                  StreamSupport.stream(
+                          RecordStream.of(zeebeEngine.getRecordStreamSource())
+                              .processInstanceRecords()
+                              .spliterator(),
+                          false)
+                      .filter(r -> r.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED)
+                      .filter(
+                          r -> r.getValue().getBpmnElementType() == BpmnElementType.BOUNDARY_EVENT)
+                      .filter(r -> r.getValue().getBpmnEventType() == BpmnEventType.ERROR)
+                      .findFirst();
 
-                        assertThat(boundaryEvent).isNotEmpty();
+              assertThat(boundaryEvent)
+                  .describedAs("Expect that the error boundary event is completed")
+                  .isNotEmpty();
 
-                        final var errorVariable =
-                            StreamSupport.stream(
-                                    RecordStream.of(zeebeEngine.getRecordStreamSource())
-                                        .variableRecords()
-                                        .spliterator(),
-                                    false)
-                                .filter(r -> r.getValue().getName().equals("error_var"))
-                                .findFirst();
+              final var errorVariable =
+                  StreamSupport.stream(
+                          RecordStream.of(zeebeEngine.getRecordStreamSource())
+                              .variableRecords()
+                              .spliterator(),
+                          false)
+                      .filter(r -> r.getValue().getName().equals("error_var"))
+                      .findFirst();
 
-                        assertThat(errorVariable)
-                            .describedAs("Expect that the error variable is set")
-                            .isPresent()
-                            .hasValueSatisfying(
-                                record ->
-                                    assertThat(record.getValue().getValue())
-                                        .isEqualTo("\"Out of coffee\""));
-                      });
+              assertThat(errorVariable)
+                  .describedAs("Expect that the error variable is set")
+                  .isPresent()
+                  .hasValueSatisfying(
+                      record ->
+                          assertThat(record.getValue().getValue()).isEqualTo("\"Out of coffee\""));
             });
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
@@ -713,6 +713,7 @@ class EngineClientTest {
                 .serviceTask("task", (task) -> task.zeebeJobType("jobType"))
                 .boundaryEvent("error")
                 .error("0xCAFE")
+                .zeebeOutputExpression("error_var", "error_var")
                 .endEvent()
                 .done(),
             "simpleProcess.bpmn")
@@ -750,6 +751,7 @@ class EngineClientTest {
                   .newThrowErrorCommand(job.getKey())
                   .errorCode("0xCAFE")
                   .errorMessage("What just happened.")
+                  .variable("error_var", "Out of coffee")
                   .send()
                   .join();
 
@@ -772,6 +774,23 @@ class EngineClientTest {
                                 .findFirst();
 
                         assertThat(boundaryEvent).isNotEmpty();
+
+                        final var errorVariable =
+                            StreamSupport.stream(
+                                    RecordStream.of(zeebeEngine.getRecordStreamSource())
+                                        .variableRecords()
+                                        .spliterator(),
+                                    false)
+                                .filter(r -> r.getValue().getName().equals("error_var"))
+                                .findFirst();
+
+                        assertThat(errorVariable)
+                            .describedAs("Expect that the error variable is set")
+                            .isPresent()
+                            .hasValueSatisfying(
+                                record ->
+                                    assertThat(record.getValue().getValue())
+                                        .isEqualTo("\"Out of coffee\""));
                       });
             });
   }


### PR DESCRIPTION
# Description
Backport of #1080 to `stable/8.2`.

relates to #1079