### PR TITLE
1011 null pointer when sending out response with no request metadata

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
@@ -99,7 +99,8 @@ public class EngineFactory {
         scheduler,
         recordStream,
         clock,
-        engineStateMonitor);
+        engineStateMonitor,
+        grpcResponseWriter);
   }
 
   private static ControlledActorClock createActorClock() {

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcResponseWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcResponseWriter.java
@@ -19,6 +19,8 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
+import java.util.List;
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -38,11 +40,16 @@ class GrpcResponseWriter implements CommandResponseWriter {
   private String rejectionReason = "";
   private final MutableDirectBuffer valueBuffer = new ExpandableArrayBuffer();
   private final GrpcResponseMapper responseMapper = new GrpcResponseMapper();
+  private final List<Intent> intents = new ArrayList<>();
 
   public GrpcResponseWriter(
       final GrpcToLogStreamGateway gateway, final GatewayRequestStore gatewayRequestStore) {
     this.gateway = gateway;
     this.gatewayRequestStore = gatewayRequestStore;
+  }
+
+  public List<Intent> getIntents() {
+    return intents;
   }
 
   @Override
@@ -109,6 +116,7 @@ class GrpcResponseWriter implements CommandResponseWriter {
       final GeneratedMessageV3 response =
           responseMapper.map(request.requestType(), valueBufferView, key, intent);
       sendResponse(request, response);
+      intents.add(intent);
     } catch (final Exception e) {
       throw new RuntimeException(e);
     }

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryEngine.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryEngine.java
@@ -41,6 +41,7 @@ public class InMemoryEngine implements ZeebeTestEngine {
   private final RecordStreamSource recordStream;
   private final ControlledActorClock clock;
   private final EngineStateMonitor engineStateMonitor;
+  private final GrpcResponseWriter grpcResponseWriter;
 
   public InMemoryEngine(
       final Server grpcServer,
@@ -51,7 +52,8 @@ public class InMemoryEngine implements ZeebeTestEngine {
       final ActorScheduler scheduler,
       final RecordStreamSource recordStream,
       final ControlledActorClock clock,
-      final EngineStateMonitor engineStateMonitor) {
+      final EngineStateMonitor engineStateMonitor,
+      final GrpcResponseWriter grpcResponseWriter) {
     this.grpcServer = grpcServer;
     this.streamProcessor = streamProcessor;
     this.gateway = gateway;
@@ -61,6 +63,7 @@ public class InMemoryEngine implements ZeebeTestEngine {
     this.recordStream = recordStream;
     this.clock = clock;
     this.engineStateMonitor = engineStateMonitor;
+    this.grpcResponseWriter = grpcResponseWriter;
   }
 
   @Override
@@ -151,5 +154,9 @@ public class InMemoryEngine implements ZeebeTestEngine {
       // Do nothing. ExecutionExceptions won't appear. The function only completes the future, which
       // in itself does not throw any exceptions.
     }
+  }
+
+  public GrpcResponseWriter getGrpcResponseWriter() {
+    return grpcResponseWriter;
   }
 }


### PR DESCRIPTION
## Description

This PR is related to [this bug](https://github.com/camunda/zeebe/issues/15649). This was fixed and backported to 8.4 and 8.3 this week. 

The initial idea was to fix ZPT [GrpcResponseWriter](https://github.com/camunda/zeebe-process-test/blob/main/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcResponseWriter.java) `tryWriteResponse` method to contain similar check that was introduced in Zeebe project:

```
    if (command.hasRequestMetadata()) {
      responseWriter.writeEventOnCommand(eventKey, SignalIntent.BROADCASTED, signalRecord, command);
    }
```

More details are available in this comment [here](https://github.com/camunda/zeebe-process-test/issues/1011#issuecomment-1921617712). I am wondering if this is still valid as after the fix for [this bug](https://github.com/camunda/zeebe/issues/15649) the response for broadcast signal events that have no corresponding request is not sent anymore:

This check in `SignalBroadcastProcessor`:

```
    if (command.hasRequestMetadata()) {
      responseWriter.writeEventOnCommand(eventKey, SignalIntent.BROADCASTED, signalRecord, command);
    }
```

is happening before `GrpcResponseWriter` is called. 

I wonder if an extra check should still be added to `GrpcResponseWriter`? Do we have other scenarios when we don't have request metadata available? I will add the check if so 👍 

What is in this draft PR:
- Unit test that verifies that no response is sent for broadcast signal event that have no corresponding request 
- More details are available in separate commit messages


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1011 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
