### PR TITLE
Test no response when no request metadata

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcResponseWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcResponseWriter.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.StreamObserver;
+import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -38,11 +39,15 @@ class GrpcResponseWriter implements CommandResponseWriter {
   private String rejectionReason = "";
   private final MutableDirectBuffer valueBuffer = new ExpandableArrayBuffer();
   private final GrpcResponseMapper responseMapper = new GrpcResponseMapper();
+  private final Consumer<Intent> requestListener;
 
   public GrpcResponseWriter(
-      final GrpcToLogStreamGateway gateway, final GatewayRequestStore gatewayRequestStore) {
+      final GrpcToLogStreamGateway gateway,
+      final GatewayRequestStore gatewayRequestStore,
+      final Consumer<Intent> requestListener) {
     this.gateway = gateway;
     this.gatewayRequestStore = gatewayRequestStore;
+    this.requestListener = requestListener;
   }
 
   @Override
@@ -109,6 +114,9 @@ class GrpcResponseWriter implements CommandResponseWriter {
       final GeneratedMessageV3 response =
           responseMapper.map(request.requestType(), valueBufferView, key, intent);
       sendResponse(request, response);
+      if (requestListener != null) {
+        requestListener.accept(intent);
+      }
     } catch (final Exception e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR is related to https://github.com/camunda/zeebe/issues/15649. This was fixed and backported to 8.4 and 8.3 this week.

Adding an optional request listener to `GrpcResponseWriter` `tryWriteResponse` method in order to verify the response is not send when there is no corresponding request.
So far we are only aware that this could happen with Intermediate Signal Throw events. 

If we have similar cases in the future we can address them then.
Please let me know if that's OK.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1011

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
