### PR TITLE
fix: db transaction inconsistencies when deleting keys

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbTransaction.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbTransaction.java
@@ -73,6 +73,10 @@ final class InMemoryDbTransaction implements ZeebeDbTransaction, InMemoryDbState
   public byte[] get(final FullyQualifiedKey fullyQualifiedKey) {
     final Bytes key = fullyQualifiedKey.getKeyBytes();
 
+    if (deletedKeys.contains(key)) {
+      return null;
+    }
+
     final Bytes valueInCache = transactionCache.get(key);
 
     if (valueInCache != null) {

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbTransaction.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbTransaction.java
@@ -108,6 +108,7 @@ final class InMemoryDbTransaction implements ZeebeDbTransaction, InMemoryDbState
   @Override
   public boolean contains(final FullyQualifiedKey fullyQualifiedKey) {
     final Bytes keyBytes = fullyQualifiedKey.getKeyBytes();
-    return transactionCache.containsKey(keyBytes) || database.containsKey(keyBytes);
+    return !deletedKeys.contains(keyBytes)
+        && (transactionCache.containsKey(keyBytes) || database.containsKey(keyBytes));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/InMemoryZeebeDbTransactionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/InMemoryZeebeDbTransactionTest.java
@@ -441,6 +441,26 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
+  void shouldAllowDeleteAndInsertInTransaction() throws Exception {
+    // given
+    oneKey.wrapLong(1);
+    oneValue.wrapLong(-1L);
+    twoValue.wrapLong(-2L);
+    oneColumnFamily.insert(oneKey, oneValue);
+    transactionContext.getCurrentTransaction().commit();
+
+    // when
+    transactionContext.runInTransaction(
+        () -> {
+          oneColumnFamily.deleteExisting(oneKey);
+          oneColumnFamily.insert(oneKey, twoValue);
+        });
+
+    // then
+    assertThat(oneColumnFamily.get(oneKey).getValue()).isEqualTo(twoValue.getValue());
+  }
+
+  @Test
   void shouldNotCommitOnError() {
     // given
     oneKey.wrapLong(1);

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/InMemoryZeebeDbTransactionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/InMemoryZeebeDbTransactionTest.java
@@ -461,6 +461,29 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
+  void shouldNotGetByKeyIfDeletedInTransaction() throws Exception {
+    // given
+    oneKey.wrapLong(1);
+    oneValue.wrapLong(-1L);
+    twoValue.wrapLong(-2L);
+    oneColumnFamily.insert(oneKey, oneValue);
+    transactionContext.getCurrentTransaction().commit();
+
+    // when
+    transactionContext.runInTransaction(
+        () -> {
+          oneColumnFamily.deleteExisting(oneKey);
+
+          if (oneColumnFamily.get(oneKey) != null) {
+            fail("Should not be able to get deleted key.");
+          }
+        });
+
+    // then
+    assertThat(oneColumnFamily.get(oneKey)).isNull();
+  }
+
+  @Test
   void shouldNotCommitOnError() {
     // given
     oneKey.wrapLong(1);


### PR DESCRIPTION
## Description

The main cause of https://github.com/camunda/zeebe-process-test/issues/1001 was the bug fixed via 77e162c5f9017df616b683aa2236ba50218698e8 . Within the same transaction you couldn't insert a previously deleted key, this happened as after processing the first processes complete command a new message start event correlation was triggered, failing as the previous active process instance was still in the database as the transaction wasn't commited and deleted keys of the transaction weren't checked.

I also noticed there was a bug in the `get` by key method, not checking the deletedKeys set either and fixed that too with bf9e1eb5c34f2d11387443253ba60dfdf03e11ed .

I verified the fix as well with the test case provided in the original issue, I decided against adding it though as the unit test covers the behavior of the db transaction that was the cause of the message start event test case failing.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1001