### PR TITLE
[Backport stable/8.3] fix: db transaction inconsistencies when deleting keys

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbTransaction.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbTransaction.java
@@ -73,6 +73,10 @@ final class InMemoryDbTransaction implements ZeebeDbTransaction, InMemoryDbState
   public byte[] get(final FullyQualifiedKey fullyQualifiedKey) {
     final Bytes key = fullyQualifiedKey.getKeyBytes();
 
+    if (deletedKeys.contains(key)) {
+      return null;
+    }
+
     final Bytes valueInCache = transactionCache.get(key);
 
     if (valueInCache != null) {

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbTransaction.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbTransaction.java
@@ -108,6 +108,7 @@ final class InMemoryDbTransaction implements ZeebeDbTransaction, InMemoryDbState
   @Override
   public boolean contains(final FullyQualifiedKey fullyQualifiedKey) {
     final Bytes keyBytes = fullyQualifiedKey.getKeyBytes();
-    return transactionCache.containsKey(keyBytes) || database.containsKey(keyBytes);
+    return !deletedKeys.contains(keyBytes)
+        && (transactionCache.containsKey(keyBytes) || database.containsKey(keyBytes));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/InMemoryZeebeDbTransactionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/InMemoryZeebeDbTransactionTest.java
@@ -441,6 +441,26 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
+  void shouldAllowDeleteAndInsertInTransaction() throws Exception {
+    // given
+    oneKey.wrapLong(1);
+    oneValue.wrapLong(-1L);
+    twoValue.wrapLong(-2L);
+    oneColumnFamily.insert(oneKey, oneValue);
+    transactionContext.getCurrentTransaction().commit();
+
+    // when
+    transactionContext.runInTransaction(
+        () -> {
+          oneColumnFamily.deleteExisting(oneKey);
+          oneColumnFamily.insert(oneKey, twoValue);
+        });
+
+    // then
+    assertThat(oneColumnFamily.get(oneKey).getValue()).isEqualTo(twoValue.getValue());
+  }
+
+  @Test
   void shouldNotCommitOnError() {
     // given
     oneKey.wrapLong(1);

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/InMemoryZeebeDbTransactionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/InMemoryZeebeDbTransactionTest.java
@@ -461,6 +461,29 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
+  void shouldNotGetByKeyIfDeletedInTransaction() throws Exception {
+    // given
+    oneKey.wrapLong(1);
+    oneValue.wrapLong(-1L);
+    twoValue.wrapLong(-2L);
+    oneColumnFamily.insert(oneKey, oneValue);
+    transactionContext.getCurrentTransaction().commit();
+
+    // when
+    transactionContext.runInTransaction(
+        () -> {
+          oneColumnFamily.deleteExisting(oneKey);
+
+          if (oneColumnFamily.get(oneKey) != null) {
+            fail("Should not be able to get deleted key.");
+          }
+        });
+
+    // then
+    assertThat(oneColumnFamily.get(oneKey)).isNull();
+  }
+
+  @Test
   void shouldNotCommitOnError() {
     // given
     oneKey.wrapLong(1);


### PR DESCRIPTION
# Description
Backport of #1139 to `stable/8.3`.

relates to camunda/zeebe-process-test#1001 #1001