### PR TITLE
Don't handle log storage append errors

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryLogStorage.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryLogStorage.java
@@ -51,17 +51,13 @@ class InMemoryLogStorage implements LogStorage {
       final long highestPosition,
       final ByteBuffer blockBuffer,
       final AppendListener listener) {
-    try {
-      logEntries.add(blockBuffer);
-      final int index = logEntries.size();
-      positionIndexMapping.put(lowestPosition, index);
-      listener.onWrite(index);
+    logEntries.add(blockBuffer);
+    final int index = logEntries.size();
+    positionIndexMapping.put(lowestPosition, index);
+    listener.onWrite(index);
 
-      listener.onCommit(index);
-      commitListeners.forEach(LogStorage.CommitListener::onCommit);
-    } catch (final Exception e) {
-      listener.onWriteError(e);
-    }
+    listener.onCommit(index);
+    commitListeners.forEach(CommitListener::onCommit);
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency.snakeyaml.version>2.2</dependency.snakeyaml.version>
     <dependency.spring.version>6.1.6</dependency.spring.version>
     <dependency.testcontainers.version>1.19.7</dependency.testcontainers.version>
-    <dependency.zeebe.version>8.5.0</dependency.zeebe.version>
+    <dependency.zeebe.version>8.6.0-SNAPSHOT</dependency.zeebe.version>
 
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR helps resolve a compile error in ZPT when building against Zeebe 8.6.0-SNAPSHOT.

To do so, it:
- bumps the zeebe version to `8.6.0-SNAPSHOT` (this is automatically adjusted by the release)
- removes the error handling in the InMemoryLogStorage's append method (this is no longer necessary)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1166 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
