### PR TITLE
fix: add context to CommandWriter

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/CommandWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/CommandWriter.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.process.test.engine;
 
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 
@@ -22,14 +23,14 @@ record CommandWriter(LogStreamWriter writer) {
   void writeCommandWithKey(
       final Long key, final UnifiedRecordValue command, final RecordMetadata recordMetadata) {
     synchronized (writer) {
-      writer.tryWrite(LogAppendEntry.of(key, recordMetadata, command));
+      writer.tryWrite(WriteContext.internal(), LogAppendEntry.of(key, recordMetadata, command));
     }
   }
 
   void writeCommandWithoutKey(
       final UnifiedRecordValue command, final RecordMetadata recordMetadata) {
     synchronized (writer) {
-      writer.tryWrite(LogAppendEntry.of(recordMetadata, command));
+      writer.tryWrite(WriteContext.internal(), LogAppendEntry.of(recordMetadata, command));
     }
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Added context to `CommandWrite` class due to the latest change in zeebe. See https://github.com/camunda/zeebe/pull/18266
