### PR TITLE
fix: add highestPosition to logStorage

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryLogStorage.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryLogStorage.java
@@ -54,9 +54,9 @@ class InMemoryLogStorage implements LogStorage {
     logEntries.add(blockBuffer);
     final int index = logEntries.size();
     positionIndexMapping.put(lowestPosition, index);
-    listener.onWrite(index);
+    listener.onWrite(index, highestPosition);
 
-    listener.onCommit(index);
+    listener.onCommit(index, highestPosition);
     commitListeners.forEach(CommitListener::onCommit);
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Added highestPosition to `InMemoryLogStorage` class due to the latest change in zeebe. See https://github.com/camunda/zeebe/pull/18297