### PR TITLE
feat: add assertions for message variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and provide you with a set of assertions you can use to verify your process beha
 > [!Note]
 > Heads up! We are building a new Java testing library for Camunda 8.6. The new library will replace Zeebe Process Test.
 > New features: Access to Camunda's new REST API, official Spring integration, process coverage, improved UX, and more ([ref](https://github.com/camunda/issues/issues/751)).
-> Stay tuned for updates. 🚀    
+> Stay tuned for updates. 🚀
 
 ## Prerequisites
 

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/MessageAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/MessageAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 camunda services GmbH (info@camunda.com)
+ * Copyright © 2021 camunda services GmbH (info@camunda.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/assertions/src/test/java/io/camunda/zeebe/process/test/assertions/MessageAssertTest.java
+++ b/assertions/src/test/java/io/camunda/zeebe/process/test/assertions/MessageAssertTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2024 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.camunda.zeebe.process.test.assertions;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.zeebe.client.api.response.PublishMessageResponse;
+import io.camunda.zeebe.process.test.filters.RecordStream;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import java.util.Collections;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class MessageAssertTest {
+
+  @AfterEach
+  void afterEach() {
+    BpmnAssert.resetRecordStream();
+  }
+
+  @Test
+  void hasVariableWithValueTest() {
+    PublishMessageResponse result = mock(PublishMessageResponse.class);
+    doReturn(123L).when(result).getMessageKey();
+
+    ProcessMessageSubscriptionRecordValue recordValue =
+        mock(ProcessMessageSubscriptionRecordValue.class);
+    doReturn(Collections.singletonMap("key", "value")).when(recordValue).getVariables();
+    doReturn(123L).when(recordValue).getMessageKey();
+
+    Record<ProcessMessageSubscriptionRecordValue> record = mock(Record.class);
+    doReturn(recordValue).when(record).getValue();
+    doReturn(ValueType.PROCESS_MESSAGE_SUBSCRIPTION).when(record).getValueType();
+    doReturn(RejectionType.NULL_VAL).when(record).getRejectionType();
+
+    BpmnAssert.initRecordStream(RecordStream.of(() -> Collections.singleton(record)));
+
+    BpmnAssert.assertThat(result).hasVariableWithValue("key", "value");
+
+    assertThatCode(() -> BpmnAssert.assertThat(result).hasVariableWithValue("foo", "value"))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageStartingWith("Unable to find variable with name 'foo'.");
+
+    assertThatCode(() -> BpmnAssert.assertThat(result).hasVariableWithValue("key", "value2"))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageStartingWith("The variable 'key' does not have the expected value.");
+  }
+}

--- a/assertions/src/test/java/io/camunda/zeebe/process/test/assertions/MessageAssertTest.java
+++ b/assertions/src/test/java/io/camunda/zeebe/process/test/assertions/MessageAssertTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 camunda services GmbH (info@camunda.com)
+ * Copyright © 2021 camunda services GmbH (info@camunda.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.camunda.zeebe.process.test.assertions;
 
 import static org.assertj.core.api.Assertions.assertThatCode;


### PR DESCRIPTION
## Description

Adds `hasVariable` and `hasVariableWithValue` to `MessageAssert`, similar to `ProcessInstanceAssert`.

## Related issues


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [x] Javadoc has been written
* [ ] The documentation is updated
