### PR TITLE
Fix httpcore5 dependency convergence issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <dependency.feel.version>1.17.7</dependency.feel.version>
     <dependency.findbugs.version>3.0.2</dependency.findbugs.version>
     <dependency.guava.version>33.2.0-jre</dependency.guava.version>
+    <dependency.httpcore5.version>5.2.5</dependency.httpcore5.version>
     <dependency.immutables.version>2.10.1</dependency.immutables.version>
     <dependency.jackson.version>2.17.0</dependency.jackson.version>
     <dependency.javax.version>1.3.2</dependency.javax.version>
@@ -404,6 +405,11 @@
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
         <version>${dependency.bytebuddy.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
+        <version>${dependency.httpcore5.version}</version>
       </dependency>
       <!-- This should be able to be removed after 1.4.0-alpha2 -->
       <dependency>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Due to a clash in dependencies ZPT gains 2 versions of httpcore5. I've set it to the latest version.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1201

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
