### PR TITLE
build: fix auto merge with merge queues

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -192,14 +192,18 @@ jobs:
       - id: approve-and-merge-dependabot
         name: Approve and merge dependabot PR
         if: github.actor == 'dependabot[bot]' && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: >
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - id: approve-and-merge-backport
         name: Approve and merge backport PR
         if: github.actor != 'dependabot[bot]'
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: >
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,10 +1,24 @@
 name: Build and test
 on:
-  pull_request: { }
   push:
     branches:
-      - 'staging'
+      - main
+      - stable/*
+      - release-*
+  pull_request: { }
+  merge_group: { }
   workflow_call: { }
+
+concurrency:
+  cancel-in-progress: true
+  group: "${{ github.workflow }}-${{ github.ref }}"
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
 jobs:
   code-formatting:
     name: check code formatting
@@ -160,7 +174,7 @@ jobs:
     # Once we're using the merge queue feature, I think we can simplify this workflow a lot by relying
     # on dependabot merging PRs via its commands, as it will always wait for checks to be green before
     # merging.
-    name: Auto-merge dependabot and camundait PRs
+    name: Auto-merge dependabot, camundait, and backport PRs
     runs-on: ubuntu-latest
     needs: [ test-summary ]
     if: github.repository == 'camunda/zeebe-process-test' && (github.actor == 'dependabot[bot]' || github.actor == 'camundait' || github.actor == 'backport-action')
@@ -178,13 +192,15 @@ jobs:
       - id: approve-and-merge-dependabot
         name: Approve and merge dependabot PR
         if: github.actor == 'dependabot[bot]' && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
-        run: gh pr review ${{ github.event.pull_request.number }} --approve -b "bors merge"
+        run: gh pr merge --auto --merge "$PR_URL"
         env:
-          GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - id: approve-and-merge-backport
         name: Approve and merge backport PR
         if: github.actor != 'dependabot[bot]'
-        run: gh pr review ${{ github.event.pull_request.number }} --approve -b "bors merge"
+        run: gh pr merge --auto --merge "$PR_URL"
         env:
-          GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 


### PR DESCRIPTION
## Description

Fixes the CI workflow, specifically enabling it for merge queues (fixing the triggers to run) and also updating the auto merge job to use the GitHub CLI to just add to the merge queue.

## Related issues

related to camunda/team-infrastructure#633

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
