### PR TITLE
Add empty logger for authorization records

### DIFF
--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -100,17 +100,17 @@ public class RecordStreamLogger {
     valueTypeLoggers.put(ValueType.ESCALATION, this::logEscalationRecordValue);
 
     // These records don't have any interesting extra information for the user to log
-    valueTypeLoggers.put(ValueType.DEPLOYMENT_DISTRIBUTION, record -> "");
-    valueTypeLoggers.put(ValueType.SBE_UNKNOWN, record -> "");
-    valueTypeLoggers.put(ValueType.NULL_VAL, record -> "");
+    valueTypeLoggers.put(ValueType.DEPLOYMENT_DISTRIBUTION, Object::toString);
+    valueTypeLoggers.put(ValueType.SBE_UNKNOWN, Object::toString);
+    valueTypeLoggers.put(ValueType.NULL_VAL, Object::toString);
 
     // DMN will not be part of the initial 1.4 release
-    valueTypeLoggers.put(ValueType.DECISION, record -> "");
-    valueTypeLoggers.put(ValueType.DECISION_REQUIREMENTS, record -> "");
-    valueTypeLoggers.put(ValueType.DECISION_EVALUATION, record -> "");
+    valueTypeLoggers.put(ValueType.DECISION, Object::toString);
+    valueTypeLoggers.put(ValueType.DECISION_REQUIREMENTS, Object::toString);
+    valueTypeLoggers.put(ValueType.DECISION_EVALUATION, Object::toString);
 
     // checkpoint isn't meant to be read by the engine
-    valueTypeLoggers.put(ValueType.CHECKPOINT, record -> "");
+    valueTypeLoggers.put(ValueType.CHECKPOINT, Object::toString);
 
     valueTypeLoggers.put(
         ValueType.PROCESS_INSTANCE_MODIFICATION, this::logProcessInstanceModificationRecordValue);
@@ -121,7 +121,7 @@ public class RecordStreamLogger {
     valueTypeLoggers.put(ValueType.RESOURCE_DELETION, this::logResourceDeletionRecordValue);
 
     valueTypeLoggers.put(ValueType.COMMAND_DISTRIBUTION, this::logCommandDistributionRecordValue);
-    valueTypeLoggers.put(ValueType.PROCESS_INSTANCE_BATCH, record -> "");
+    valueTypeLoggers.put(ValueType.PROCESS_INSTANCE_BATCH, Object::toString);
     valueTypeLoggers.put(ValueType.FORM, this::logFormRecordValue);
     valueTypeLoggers.put(ValueType.USER_TASK, this::logUserTaskRecordValue);
     valueTypeLoggers.put(
@@ -131,7 +131,7 @@ public class RecordStreamLogger {
     valueTypeLoggers.put(ValueType.MESSAGE_CORRELATION, this::logMessageCorrelationRecordValue);
     valueTypeLoggers.put(ValueType.USER, this::logUsersRecordValue);
     valueTypeLoggers.put(ValueType.CLOCK, this::logClockRecordValue);
-    valueTypeLoggers.put(ValueType.AUTHORIZATION, record -> "");
+    valueTypeLoggers.put(ValueType.AUTHORIZATION, Object::toString);
   }
 
   public void log() {

--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -131,6 +131,7 @@ public class RecordStreamLogger {
     valueTypeLoggers.put(ValueType.MESSAGE_CORRELATION, this::logMessageCorrelationRecordValue);
     valueTypeLoggers.put(ValueType.USER, this::logUsersRecordValue);
     valueTypeLoggers.put(ValueType.CLOCK, this::logClockRecordValue);
+    valueTypeLoggers.put(ValueType.AUTHORIZATION, record -> "");
   }
 
   public void log() {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Authorizations aren't supported in the next version. The record is bound to change so it's not worth adding a proper logger for this value type right now. It likely isn't worth adding one in the future either, since ZPT is in the process of being deprecated.

## Related issues


<!-- Which issues are closed by this PR or are related -->

N/A

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
