### PR TITLE
fix: quick fix for a timer bug

### DIFF
--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -100,17 +100,17 @@ public class RecordStreamLogger {
     valueTypeLoggers.put(ValueType.ESCALATION, this::logEscalationRecordValue);
 
     // These records don't have any interesting extra information for the user to log
-    valueTypeLoggers.put(ValueType.DEPLOYMENT_DISTRIBUTION, record -> "");
-    valueTypeLoggers.put(ValueType.SBE_UNKNOWN, record -> "");
-    valueTypeLoggers.put(ValueType.NULL_VAL, record -> "");
+    valueTypeLoggers.put(ValueType.DEPLOYMENT_DISTRIBUTION, Object::toString);
+    valueTypeLoggers.put(ValueType.SBE_UNKNOWN, Object::toString);
+    valueTypeLoggers.put(ValueType.NULL_VAL, Object::toString);
 
     // DMN will not be part of the initial 1.4 release
-    valueTypeLoggers.put(ValueType.DECISION, record -> "");
-    valueTypeLoggers.put(ValueType.DECISION_REQUIREMENTS, record -> "");
-    valueTypeLoggers.put(ValueType.DECISION_EVALUATION, record -> "");
+    valueTypeLoggers.put(ValueType.DECISION, Object::toString);
+    valueTypeLoggers.put(ValueType.DECISION_REQUIREMENTS, Object::toString);
+    valueTypeLoggers.put(ValueType.DECISION_EVALUATION, Object::toString);
 
     // checkpoint isn't meant to be read by the engine
-    valueTypeLoggers.put(ValueType.CHECKPOINT, record -> "");
+    valueTypeLoggers.put(ValueType.CHECKPOINT, Object::toString);
 
     valueTypeLoggers.put(
         ValueType.PROCESS_INSTANCE_MODIFICATION, this::logProcessInstanceModificationRecordValue);
@@ -121,7 +121,7 @@ public class RecordStreamLogger {
     valueTypeLoggers.put(ValueType.RESOURCE_DELETION, this::logResourceDeletionRecordValue);
 
     valueTypeLoggers.put(ValueType.COMMAND_DISTRIBUTION, this::logCommandDistributionRecordValue);
-    valueTypeLoggers.put(ValueType.PROCESS_INSTANCE_BATCH, record -> "");
+    valueTypeLoggers.put(ValueType.PROCESS_INSTANCE_BATCH, Object::toString);
     valueTypeLoggers.put(ValueType.FORM, this::logFormRecordValue);
     valueTypeLoggers.put(ValueType.USER_TASK, this::logUserTaskRecordValue);
     valueTypeLoggers.put(
@@ -131,6 +131,7 @@ public class RecordStreamLogger {
     valueTypeLoggers.put(ValueType.MESSAGE_CORRELATION, this::logMessageCorrelationRecordValue);
     valueTypeLoggers.put(ValueType.USER, this::logUsersRecordValue);
     valueTypeLoggers.put(ValueType.CLOCK, this::logClockRecordValue);
+    valueTypeLoggers.put(ValueType.AUTHORIZATION, Object::toString);
   }
 
   public void log() {

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/jobs/AbstractTimerTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/jobs/AbstractTimerTest.java
@@ -52,12 +52,12 @@ public abstract class AbstractTimerTest {
 
   private static Stream<Arguments> dates() {
     return Stream.of(
-        Arguments.of(OffsetDateTime.of(2023, 10, 5, 15, 50, 0, 0, ZoneOffset.of("+02:00"))),
-        Arguments.of(OffsetDateTime.of(2023, 10, 31, 0, 0, 0, 0, ZoneOffset.of("+02:00"))),
-        Arguments.of(OffsetDateTime.of(2023, 10, 31, 23, 0, 0, 0, ZoneOffset.of("+02:00"))),
-        Arguments.of(OffsetDateTime.of(2023, 10, 31, 23, 59, 0, 0, ZoneOffset.of("+02:00"))),
-        Arguments.of(OffsetDateTime.of(2023, 10, 31, 23, 59, 59, 0, ZoneOffset.of("+02:00"))),
-        Arguments.of(OffsetDateTime.of(2023, 12, 31, 23, 59, 59, 0, ZoneOffset.of("+02:00"))));
+        Arguments.of(OffsetDateTime.of(2024, 10, 5, 15, 50, 0, 0, ZoneOffset.of("+02:00"))),
+        Arguments.of(OffsetDateTime.of(2024, 10, 31, 0, 0, 0, 0, ZoneOffset.of("+02:00"))),
+        Arguments.of(OffsetDateTime.of(2024, 10, 31, 23, 0, 0, 0, ZoneOffset.of("+02:00"))),
+        Arguments.of(OffsetDateTime.of(2024, 10, 31, 23, 59, 0, 0, ZoneOffset.of("+02:00"))),
+        Arguments.of(OffsetDateTime.of(2024, 10, 31, 23, 59, 59, 0, ZoneOffset.of("+02:00"))),
+        Arguments.of(OffsetDateTime.of(2024, 12, 31, 23, 59, 59, 0, ZoneOffset.of("+02:00"))));
   }
 
   @BeforeEach


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Fixed-rate timers don't play nicely with backward time adjustments. For fixed rate timers, an execution is scheduled for ex. 5 seconds in the future. When that execution runs, it schedules the next one, etc. However, when traveling backwards in time, the next scheduled execution never triggers.

The issue needs to be fixed properly in Zeebe. A temporary workaround is to adjust the tests with a future date time.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to #1230

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
