### PR TITLE
Remove all references of actor scheduler from logstream

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
@@ -67,7 +67,7 @@ public class EngineFactory {
     final ActorScheduler scheduler = createAndStartActorScheduler(clock);
 
     final InMemoryLogStorage logStorage = new InMemoryLogStorage();
-    final LogStream logStream = createLogStream(logStorage, scheduler, partitionId, clock);
+    final LogStream logStream = createLogStream(logStorage, partitionId, clock);
 
     final CommandWriter commandWriter = new CommandWriter(logStream.newLogStreamWriter());
     final CommandSender commandSender = new CommandSender(commandWriter);
@@ -124,10 +124,7 @@ public class EngineFactory {
   }
 
   private static LogStream createLogStream(
-      final LogStorage logStorage,
-      final ActorSchedulingService scheduler,
-      final int partitionId,
-      final ActorClock clock) {
+      final LogStorage logStorage, final int partitionId, final ActorClock clock) {
     return LogStream.builder()
         .withPartitionId(partitionId)
         .withLogStorage(logStorage)

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
@@ -131,7 +131,6 @@ public class EngineFactory {
     return LogStream.builder()
         .withPartitionId(partitionId)
         .withLogStorage(logStorage)
-        .withActorSchedulingService(scheduler)
         .withClock(clock)
         .build();
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This applies the recent changes of https://github.com/camunda/camunda/pull/22870 to ZPT. The Logstream no longer needs the actor scheduler, as it no longer schedules tasks asynchronously.

This change broke compilation of ZPT against the Zeebe SNAPSHOT version.

## Related issues

<!-- Which issues are closed by this PR or are related -->

NA

Failed a compilation run [here](https://github.com/camunda/zeebe-process-test/actions/runs/11137105744/job/30950000020).

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
