### PR TITLE
fix: add logger for scale records

### DIFF
--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -134,6 +134,7 @@ public class RecordStreamLogger {
     valueTypeLoggers.put(ValueType.AUTHORIZATION, Object::toString);
     valueTypeLoggers.put(ValueType.ROLE, Object::toString);
     valueTypeLoggers.put(ValueType.TENANT, Object::toString);
+    valueTypeLoggers.put(ValueType.SCALE, Object::toString);
   }
 
   public void log() {


### PR DESCRIPTION
Fixes a compilation error introduces by https://github.com/camunda/camunda/pull/23192: https://github.com/camunda/zeebe-process-test/actions/runs/11320306143/job/31477650086

