### PR TITLE
fix: update grpc version to 1.68.0 to fix incompatiblity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,8 @@
 
     <skipChecks>false</skipChecks>
 
-    <version.grpc>1.65.1</version.grpc>
+    <!-- Note: needs to be aligned with the version used by io.camunda:zeebe-client-java -->
+    <version.grpc>1.68.0</version.grpc>
     <version.java>21</version.java>
     <version.protobuf>3.19.4</version.protobuf>
   </properties>

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/injection/AbstractInheritanceInjectionTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/injection/AbstractInheritanceInjectionTest.java
@@ -19,6 +19,7 @@ package io.camunda.zeebe.process.test.qa.abstracts.injection;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.Topology;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import org.junit.jupiter.api.Test;
 
@@ -30,5 +31,11 @@ public abstract class AbstractInheritanceInjectionTest {
   void testFieldsAreInjectedSuccessfully() {
     assertThat(client).isNotNull();
     assertThat(engine).isNotNull();
+  }
+
+  @Test
+  void testClientCanSendCommand() {
+    final Topology topology = client.newTopologyRequest().send().join();
+    assertThat(topology.getGatewayVersion()).isNotNull();
   }
 }


### PR DESCRIPTION
## Description

The io.camunda:zeebe-client-java was already using 1.68.0 while ZPT used 1.65.1 which caused the client to fail. As ZPT itself depends on GRPC we need to keep both versions generally in sync.

Kudos to @saig0 for root-causing this!

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1257

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
