### PR TITLE
[Backport stable/8.6] fix: update grpc version to 1.68.0 to fix incompatiblity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,8 @@
 
     <skipChecks>false</skipChecks>
 
-    <version.grpc>1.65.1</version.grpc>
+    <!-- Note: needs to be aligned with the version used by io.camunda:zeebe-client-java -->
+    <version.grpc>1.68.0</version.grpc>
     <version.java>21</version.java>
     <version.protobuf>3.19.4</version.protobuf>
   </properties>

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/injection/AbstractInheritanceInjectionTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/injection/AbstractInheritanceInjectionTest.java
@@ -19,6 +19,7 @@ package io.camunda.zeebe.process.test.qa.abstracts.injection;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.Topology;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import org.junit.jupiter.api.Test;
 
@@ -30,5 +31,11 @@ public abstract class AbstractInheritanceInjectionTest {
   void testFieldsAreInjectedSuccessfully() {
     assertThat(client).isNotNull();
     assertThat(engine).isNotNull();
+  }
+
+  @Test
+  void testClientCanSendCommand() {
+    final Topology topology = client.newTopologyRequest().send().join();
+    assertThat(topology.getGatewayVersion()).isNotNull();
   }
 }


### PR DESCRIPTION
# Description
Backport of #1258 to `stable/8.6`.

relates to #1257