### PR TITLE
feat: add REDISTRIBUTION value type to logger

### DIFF
--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -137,6 +137,7 @@ public class RecordStreamLogger {
     valueTypeLoggers.put(ValueType.SCALE, Object::toString);
     valueTypeLoggers.put(ValueType.GROUP, Object::toString);
     valueTypeLoggers.put(ValueType.MAPPING, Object::toString);
+    valueTypeLoggers.put(ValueType.REDISTRIBUTION, Object::toString);
   }
 
   public void log() {


### PR DESCRIPTION
## Description

Adds the REDISTRIBUTION value type to the record logger introduced with https://github.com/camunda/camunda/pull/24260.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda/camunda/issues/24013

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
