### PR TITLE
Log identity setup record using toString

### DIFF
--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -138,6 +138,7 @@ public class RecordStreamLogger {
     valueTypeLoggers.put(ValueType.GROUP, Object::toString);
     valueTypeLoggers.put(ValueType.MAPPING, Object::toString);
     valueTypeLoggers.put(ValueType.REDISTRIBUTION, Object::toString);
+    valueTypeLoggers.put(ValueType.IDENTITY_SETUP, Object::toString);
   }
 
   public void log() {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Adds the ability to the RecordStreamLogger to log records of value type IDENTITY_SETUP using the toString method. This is better than not logging anything, but means the output is json formatted.

This fixes a failing test case.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1269 