### PR TITLE
Add note that Spring support is unavailable in 8.6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Using Maven profiles you can also [switch the test dependencies based on the ava
 
 ### Spring support
 
+> [!Note]
+> Spring support with Zeebe Process Test uses the community-supported Spring Zeebe SDK.
+> Spring support is not available for Camunda 8.6+. 
+
 If you use the Spring framework or Spring Boot and you want to write tests, please use `spring-zeebe-test` as a wrapper around this library. This will hook everything into the Spring lifecycle. See [Spring Zeebe: Writing test cases](https://github.com/camunda-community-hub/spring-zeebe#writing-test-cases) for details.
 
 ### Annotation


### PR DESCRIPTION
## Description

Spring support with Zeebe Process Test is not available from 8.6+ and comes from a community-supported SDK. This is not clear and causing support tickets, so we add a note that this is unavailable.

More internal context can be found [here](https://camunda.slack.com/archives/C06VC96GMNE/p1734021018422249?thread_ts=1729598950.187899&cid=C06VC96GMNE).

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [x] The documentation is updated
