### PR TITLE
Migrate to camunda-client-java

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Annotate your test class with the `@ZeebeProcessTest` annotation. This annotatio
 3. It will (optionally) inject 3 fields in your test class:
    1. `ZeebeTestEngine` - This is the engine that will run your process. It will provide some basic functionality
       to help you write your tests, such as waiting for an idle state and increasing the time.
-   2. `ZeebeClient` - This is the client that allows you to  send commands to the engine, such as
+   2. `CamundaClient` - This is the client that allows you to  send commands to the engine, such as
       starting a process instance. The interface of this client is identical to the interface you
       use to connect to a real Zeebe engine.
    3. `RecordStream` - This gives you access to all the records that are processed by the engine.
@@ -98,7 +98,7 @@ import io.camunda.zeebe.process.test.extension.testcontainer.ZeebeProcessTest;
 @ZeebeProcessTest
 class DeploymentAssertTest {
   private ZeebeTestEngine engine;
-  private ZeebeClient client;
+  private CamundaClient client;
   private RecordStream recordStream;
 }
 ```
@@ -242,7 +242,7 @@ A custom `ObjectMapper` can be provided to the `Zeebe Client`
 @ZeebeProcessTest
 class MyProcessTest {
   private ZeebeTestEngine engine;
-  private ZeebeClient client;
+  private CamundaClient client;
   private ObjectMapper mapper = setupMapper();
 
 

--- a/api/ignored-changes.json
+++ b/api/ignored-changes.json
@@ -1,0 +1,22 @@
+[
+  {
+    "extension": "revapi.differences",
+    "id": "differences",
+    "configuration": {
+      "differences": [
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "new": "method io.camunda.client.CamundaClient io.camunda.zeebe.process.test.api.ZeebeTestEngine::createClient()",
+          "justification": "Migration from zeebe-client-java to camunda-client-java"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "new": "method io.camunda.client.CamundaClient io.camunda.zeebe.process.test.api.ZeebeTestEngine::createClient(com.fasterxml.jackson.databind.ObjectMapper)",
+          "justification": "Migration from zeebe-client-java to camunda-client-java"
+        }
+      ]
+    }
+  }
+]

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -29,7 +29,7 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-client-java</artifactId>
+      <artifactId>camunda-client-java</artifactId>
     </dependency>
 
     <dependency>

--- a/api/revapi.json
+++ b/api/revapi.json
@@ -15,14 +15,7 @@
     "extension": "revapi.differences",
     "id": "differences",
     "configuration": {
-      "differences": [
-        {
-          "ignore": true,
-          "code": "java.method.addedToInterface",
-          "new": "method io.camunda.zeebe.client.ZeebeClient io.camunda.zeebe.process.test.api.ZeebeTestEngine::createClient(com.fasterxml.jackson.databind.ObjectMapper)",
-          "justification": ""
-        }
-      ]
+      "differences": []
     }
   }
 ]

--- a/api/src/main/java/io/camunda/zeebe/process/test/api/ZeebeTestEngine.java
+++ b/api/src/main/java/io/camunda/zeebe/process/test/api/ZeebeTestEngine.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.process.test.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.client.CamundaClient;
 import java.time.Duration;
 import java.util.concurrent.TimeoutException;
 
@@ -38,14 +38,14 @@ public interface ZeebeTestEngine {
   RecordStreamSource getRecordStreamSource();
 
   /**
-   * @return a newly created {@link ZeebeClient}
+   * @return a newly created {@link CamundaClient}
    */
-  ZeebeClient createClient();
+  CamundaClient createClient();
 
   /**
-   * @return a newly created {@link ZeebeClient} with custom mapper
+   * @return a newly created {@link CamundaClient} with custom mapper
    */
-  ZeebeClient createClient(ObjectMapper customObjectMapper);
+  CamundaClient createClient(ObjectMapper customObjectMapper);
 
   /**
    * @return the address at which the gateway is reachable

--- a/assertions/ignored-changes.json
+++ b/assertions/ignored-changes.json
@@ -1,0 +1,82 @@
+[
+  {
+    "extension": "revapi.differences",
+    "id": "differences",
+    "configuration": {
+      "differences": [
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0-SNAPSHOT",
+          "justification": "Migration from zeebe-client-java to camunda-client-java"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0-SNAPSHOT",
+          "justification": "Migration from zeebe-client-java to camunda-client-java"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeChanged",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0-SNAPSHOT",
+          "justification": "Migration from zeebe-client-java to camunda-client-java"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.typeChanged",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0-SNAPSHOT",
+          "justification": "Migration from zeebe-client-java to camunda-client-java"
+        },
+        {
+          "ignore": true,
+          "code": "java.class.noLongerImplementsInterface",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0-SNAPSHOT",
+          "justification": "Migration from zeebe-client-java to camunda-client-java"
+        },
+        {
+          "ignore": true,
+          "code": "java.class.superTypeTypeParametersChanged",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0-SNAPSHOT",
+          "justification": "Migration from zeebe-client-java to camunda-client-java"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0",
+          "justification": "Migration from zeebe-client-java to camunda-client-java"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeParameterChanged",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0",
+          "justification": "Migration from zeebe-client-java to camunda-client-java"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeChanged",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0",
+          "justification": "Migration from zeebe-client-java to camunda-client-java"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.typeChanged",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0",
+          "justification": "Migration from zeebe-client-java to camunda-client-java"
+        },
+        {
+          "ignore": true,
+          "code": "java.class.noLongerImplementsInterface",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0",
+          "justification": "Migration from zeebe-client-java to camunda-client-java"
+        },
+        {
+          "ignore": true,
+          "code": "java.class.superTypeTypeParametersChanged",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0",
+          "justification": "Migration from zeebe-client-java to camunda-client-java"
+        }
+      ]
+    }
+  }
+]

--- a/assertions/pom.xml
+++ b/assertions/pom.xml
@@ -39,7 +39,7 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-client-java</artifactId>
+      <artifactId>camunda-client-java</artifactId>
     </dependency>
 
     <dependency>

--- a/assertions/revapi.json
+++ b/assertions/revapi.json
@@ -10,5 +10,12 @@
         ]
       }
     }
+  },
+  {
+    "extension": "revapi.differences",
+    "id": "differences",
+    "configuration": {
+      "differences": []
+    }
   }
 ]

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/ObjectMapperConfig.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/ObjectMapperConfig.java
@@ -17,25 +17,25 @@
 package io.camunda.zeebe.process.test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import io.camunda.client.impl.CamundaObjectMapper;
 
 /** Shared custom {@link ObjectMapper} configured by the user */
 public class ObjectMapperConfig {
 
-  private static final ThreadLocal<ZeebeObjectMapper> objectMapper = new ThreadLocal<>();
+  private static final ThreadLocal<CamundaObjectMapper> objectMapper = new ThreadLocal<>();
 
   static {
-    objectMapper.set(new ZeebeObjectMapper());
+    objectMapper.set(new CamundaObjectMapper());
   }
 
   /**
    * @return the configured {@link ObjectMapper}.
    */
-  public static ZeebeObjectMapper getObjectMapper() {
+  public static CamundaObjectMapper getObjectMapper() {
     return ObjectMapperConfig.objectMapper.get();
   }
 
   public static void initObjectMapper(final ObjectMapper objectMapper) {
-    ObjectMapperConfig.objectMapper.set(new ZeebeObjectMapper(objectMapper));
+    ObjectMapperConfig.objectMapper.set(new CamundaObjectMapper(objectMapper));
   }
 }

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/BpmnAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/BpmnAssert.java
@@ -15,11 +15,11 @@
  */
 package io.camunda.zeebe.process.test.assertions;
 
-import io.camunda.zeebe.client.api.response.ActivatedJob;
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
-import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
-import io.camunda.zeebe.client.api.response.PublishMessageResponse;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.DeploymentEvent;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.response.ProcessInstanceResult;
+import io.camunda.client.api.response.PublishMessageResponse;
 import io.camunda.zeebe.process.test.filters.RecordStream;
 import io.camunda.zeebe.process.test.inspections.model.InspectedProcessInstance;
 

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/DeploymentAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/DeploymentAssert.java
@@ -18,9 +18,9 @@ package io.camunda.zeebe.process.test.assertions;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
-import io.camunda.zeebe.client.api.response.Form;
-import io.camunda.zeebe.client.api.response.Process;
+import io.camunda.client.api.response.DeploymentEvent;
+import io.camunda.client.api.response.Form;
+import io.camunda.client.api.response.Process;
 import io.camunda.zeebe.process.test.filters.RecordStream;
 import java.util.List;
 import org.assertj.core.api.AbstractAssert;

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/FormAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/FormAssert.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.process.test.assertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.client.api.response.Form;
+import io.camunda.client.api.response.Form;
 import io.camunda.zeebe.process.test.filters.RecordStream;
 import io.camunda.zeebe.process.test.filters.StreamFilter;
 import io.camunda.zeebe.protocol.record.Record;

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/IncidentAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/IncidentAssert.java
@@ -17,8 +17,8 @@ package io.camunda.zeebe.process.test.assertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.client.api.response.ActivatedJob;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.process.test.filters.IncidentRecordStreamFilter;
 import io.camunda.zeebe.process.test.filters.RecordStream;
 import io.camunda.zeebe.process.test.filters.StreamFilter;

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/JobAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/JobAssert.java
@@ -17,7 +17,7 @@ package io.camunda.zeebe.process.test.assertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.zeebe.process.test.filters.IncidentRecordStreamFilter;
 import io.camunda.zeebe.process.test.filters.RecordStream;
 import io.camunda.zeebe.process.test.filters.StreamFilter;

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/MessageAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/MessageAssert.java
@@ -17,7 +17,7 @@ package io.camunda.zeebe.process.test.assertions;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import io.camunda.zeebe.client.api.response.PublishMessageResponse;
+import io.camunda.client.api.response.PublishMessageResponse;
 import io.camunda.zeebe.process.test.filters.RecordStream;
 import io.camunda.zeebe.process.test.filters.StreamFilter;
 import io.camunda.zeebe.protocol.record.Record;
@@ -36,7 +36,7 @@ import org.assertj.core.api.Assertions;
 /** Assertions for {@link PublishMessageResponse} instances */
 public class MessageAssert extends AbstractAssert<MessageAssert, PublishMessageResponse> {
 
-  private RecordStream recordStream;
+  private final RecordStream recordStream;
 
   protected MessageAssert(final PublishMessageResponse actual, final RecordStream recordStream) {
     super(actual, MessageAssert.class);

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/ProcessAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/ProcessAssert.java
@@ -17,7 +17,7 @@ package io.camunda.zeebe.process.test.assertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.client.api.response.Process;
+import io.camunda.client.api.response.Process;
 import io.camunda.zeebe.process.test.filters.RecordStream;
 import io.camunda.zeebe.process.test.filters.StreamFilter;
 import io.camunda.zeebe.protocol.record.Record;

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/VariablesMapAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/VariablesMapAssert.java
@@ -19,7 +19,7 @@ package io.camunda.zeebe.process.test.assertions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.zeebe.process.test.ObjectMapperConfig;
 import java.util.Map;
 import org.assertj.core.api.AbstractAssert;
@@ -30,7 +30,7 @@ import org.assertj.core.api.AbstractAssert;
  */
 public class VariablesMapAssert extends AbstractAssert<VariablesMapAssert, Map<String, String>> {
 
-  private final ZeebeObjectMapper objectMapper = ObjectMapperConfig.getObjectMapper();
+  private final CamundaObjectMapper objectMapper = ObjectMapperConfig.getObjectMapper();
 
   public VariablesMapAssert(final Map<String, String> actual) {
     super(actual, VariablesMapAssert.class);

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/inspections/ProcessDefinitionInspectionUtility.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/inspections/ProcessDefinitionInspectionUtility.java
@@ -16,7 +16,7 @@
 
 package io.camunda.zeebe.process.test.inspections;
 
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.filters.StreamFilter;
@@ -41,7 +41,7 @@ public class ProcessDefinitionInspectionUtility {
    * @param bpmnElementName the name of the BPMN element
    * @return the id of the found BPMN element
    */
-  public static String getBpmnElementId(String bpmnElementName) {
+  public static String getBpmnElementId(final String bpmnElementName) {
     return getBpmnElementId(
         StreamFilter.processRecords(BpmnAssert.getRecordStream()).getProcessDefinitions(),
         bpmnElementName);
@@ -57,7 +57,7 @@ public class ProcessDefinitionInspectionUtility {
    * @param bpmnElementName the name of the BPMN element
    * @return the id of the found BPMN in the given process
    */
-  public static String getBpmnElementId(String bpmnProcessId, String bpmnElementName) {
+  public static String getBpmnElementId(final String bpmnProcessId, final String bpmnElementName) {
     return getBpmnElementId(
         StreamFilter.processRecords(BpmnAssert.getRecordStream())
             .withBpmnProcessId(bpmnProcessId)
@@ -75,7 +75,8 @@ public class ProcessDefinitionInspectionUtility {
    * @param bpmnElementName
    * @return
    */
-  public static String getBpmnElementId(DeploymentEvent deployment, String bpmnElementName) {
+  public static String getBpmnElementId(
+      final DeploymentEvent deployment, final String bpmnElementName) {
     return getBpmnElementId(
         StreamFilter.processRecords(BpmnAssert.getRecordStream())
             .withDeployment(deployment)
@@ -83,8 +84,9 @@ public class ProcessDefinitionInspectionUtility {
         bpmnElementName);
   }
 
-  private static String getBpmnElementId(Stream<Process> stream, String bpmnElementName) {
-    List<String> potentialElementIds =
+  private static String getBpmnElementId(
+      final Stream<Process> stream, final String bpmnElementName) {
+    final List<String> potentialElementIds =
         stream
             .map(
                 processResource ->
@@ -102,8 +104,8 @@ public class ProcessDefinitionInspectionUtility {
     return potentialElementIds.get(0);
   }
 
-  private static Set<DomElement> getChildElementsFlattened(DomElement parent) {
-    Set<DomElement> elements = new HashSet<>();
+  private static Set<DomElement> getChildElementsFlattened(final DomElement parent) {
+    final Set<DomElement> elements = new HashSet<>();
     elements.add(parent);
     parent.getChildElements().forEach(child -> elements.addAll(getChildElementsFlattened(child)));
     return elements;

--- a/assertions/src/test/java/io/camunda/zeebe/process/test/assertions/BpmnAssertTest.java
+++ b/assertions/src/test/java/io/camunda/zeebe/process/test/assertions/BpmnAssertTest.java
@@ -18,11 +18,11 @@ package io.camunda.zeebe.process.test.assertions;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
 
-import io.camunda.zeebe.client.api.response.ActivatedJob;
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
-import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
-import io.camunda.zeebe.client.api.response.PublishMessageResponse;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.DeploymentEvent;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.response.ProcessInstanceResult;
+import io.camunda.client.api.response.PublishMessageResponse;
 import io.camunda.zeebe.process.test.filters.RecordStream;
 import io.camunda.zeebe.process.test.inspections.model.InspectedProcessInstance;
 import org.junit.jupiter.api.AfterEach;
@@ -46,10 +46,10 @@ class BpmnAssertTest {
   @DisplayName("Should return ProcessInstanceAssert for ProcessInstanceEvent")
   void testAssertThatProcessInstanceEventReturnsProcessInstanceAssert() {
     // given
-    ProcessInstanceEvent event = mock(ProcessInstanceEvent.class);
+    final ProcessInstanceEvent event = mock(ProcessInstanceEvent.class);
 
     // when
-    ProcessInstanceAssert assertions = BpmnAssert.assertThat(event);
+    final ProcessInstanceAssert assertions = BpmnAssert.assertThat(event);
 
     // then
     assertThat(assertions).isInstanceOf(ProcessInstanceAssert.class);
@@ -59,10 +59,10 @@ class BpmnAssertTest {
   @DisplayName("Should return ProcessInstanceAssert for ProcessInstanceResult")
   void testAssertThatProcessInstanceResultReturnsProcessInstanceAssert() {
     // given
-    ProcessInstanceResult result = mock(ProcessInstanceResult.class);
+    final ProcessInstanceResult result = mock(ProcessInstanceResult.class);
 
     // when
-    ProcessInstanceAssert assertions = BpmnAssert.assertThat(result);
+    final ProcessInstanceAssert assertions = BpmnAssert.assertThat(result);
 
     // then
     assertThat(assertions).isInstanceOf(ProcessInstanceAssert.class);
@@ -72,10 +72,10 @@ class BpmnAssertTest {
   @DisplayName("Should return ProcessInstanceAssert for InspectedProcessInstance")
   void testAssertThatInspectedProcessInstanceReturnsProcessInstanceAssert() {
     // given
-    InspectedProcessInstance inspected = mock(InspectedProcessInstance.class);
+    final InspectedProcessInstance inspected = mock(InspectedProcessInstance.class);
 
     // when
-    ProcessInstanceAssert assertions = BpmnAssert.assertThat(inspected);
+    final ProcessInstanceAssert assertions = BpmnAssert.assertThat(inspected);
 
     // then
     assertThat(assertions).isInstanceOf(ProcessInstanceAssert.class);
@@ -85,10 +85,10 @@ class BpmnAssertTest {
   @DisplayName("Should return JobAssert for ActivatedJob")
   void testAssertThatActivatedJobReturnsJobAssert() {
     // given
-    ActivatedJob job = mock(ActivatedJob.class);
+    final ActivatedJob job = mock(ActivatedJob.class);
 
     // when
-    JobAssert assertions = BpmnAssert.assertThat(job);
+    final JobAssert assertions = BpmnAssert.assertThat(job);
 
     // then
     assertThat(assertions).isInstanceOf(JobAssert.class);
@@ -98,10 +98,10 @@ class BpmnAssertTest {
   @DisplayName("Should return DeploymentAssert for DeploymentEvent")
   void testAssertThatDeploymentEventReturnsDeploymentAssert() {
     // given
-    DeploymentEvent event = mock(DeploymentEvent.class);
+    final DeploymentEvent event = mock(DeploymentEvent.class);
 
     // when
-    DeploymentAssert assertions = BpmnAssert.assertThat(event);
+    final DeploymentAssert assertions = BpmnAssert.assertThat(event);
 
     // then
     assertThat(assertions).isInstanceOf(DeploymentAssert.class);
@@ -111,10 +111,10 @@ class BpmnAssertTest {
   @DisplayName("Should return MessageAssert for PublishMessageResponse")
   void testAssertThatPublishMessageResponseReturnsMessageAssert() {
     // given
-    PublishMessageResponse event = mock(PublishMessageResponse.class);
+    final PublishMessageResponse event = mock(PublishMessageResponse.class);
 
     // when
-    MessageAssert assertions = BpmnAssert.assertThat(event);
+    final MessageAssert assertions = BpmnAssert.assertThat(event);
 
     // then
     assertThat(assertions).isInstanceOf(MessageAssert.class);

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -141,6 +141,11 @@
       <artifactId>micrometer-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-core</artifactId>
+    </dependency>
+
     <!-- Test Scope -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -53,7 +53,7 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-client-java</artifactId>
+      <artifactId>camunda-client-java</artifactId>
     </dependency>
 
     <dependency>

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.process.test.engine;
 
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.Engine;
 import io.camunda.zeebe.engine.EngineConfiguration;
@@ -162,7 +163,8 @@ public class EngineFactory {
                             commandSender,
                             FeatureFlags.createDefault(),
                             jobStreamer),
-                    new EngineConfiguration())))
+                    new EngineConfiguration(),
+                    new SecurityConfiguration())))
         .actorSchedulingService(scheduler)
         .clock(new ControllableStreamClockImpl(clock))
         .meterRegistry(new SimpleMeterRegistry())

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/GatewayRequestStore.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/GatewayRequestStore.java
@@ -8,7 +8,7 @@
 
 package io.camunda.zeebe.process.test.engine;
 
-import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.GeneratedMessage;
 import io.grpc.stub.StreamObserver;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -24,7 +24,7 @@ class GatewayRequestStore {
   private final AtomicLong requestIdGenerator = new AtomicLong();
 
   Long registerNewRequest(
-      final Class<? extends GeneratedMessageV3> requestType,
+      final Class<? extends GeneratedMessage> requestType,
       final StreamObserver<?> responseObserver) {
     final long currentRequestId = requestIdGenerator.incrementAndGet();
     requestMap.put(currentRequestId, new Request(requestType, responseObserver));
@@ -36,5 +36,5 @@ class GatewayRequestStore {
   }
 
   record Request(
-      Class<? extends GeneratedMessageV3> requestType, StreamObserver<?> responseObserver) {}
+      Class<? extends GeneratedMessage> requestType, StreamObserver<?> responseObserver) {}
 }

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcResponseMapper.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcResponseMapper.java
@@ -8,7 +8,7 @@
 
 package io.camunda.zeebe.process.test.engine;
 
-import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.GeneratedMessage;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
@@ -82,7 +82,7 @@ class GrpcResponseMapper {
   private long key;
   private Intent intent;
 
-  private final Map<Class<? extends GeneratedMessageV3>, Callable<GeneratedMessageV3>> mappers =
+  private final Map<Class<? extends GeneratedMessage>, Callable<GeneratedMessage>> mappers =
       Map.ofEntries(
           Map.entry(ActivateJobsRequest.class, this::createJobBatchResponse),
           Map.entry(CancelProcessInstanceRequest.class, this::createCancelInstanceResponse),
@@ -106,8 +106,8 @@ class GrpcResponseMapper {
               MigrateProcessInstanceRequest.class, this::createMigrateProcessInstanceResponse),
           Map.entry(BroadcastSignalRequest.class, this::createBroadcastSignalResponse));
 
-  GeneratedMessageV3 map(
-      final Class<? extends GeneratedMessageV3> requestType,
+  GeneratedMessage map(
+      final Class<? extends GeneratedMessage> requestType,
       final DirectBuffer valueBufferView,
       final long key,
       final Intent intent) {
@@ -142,7 +142,7 @@ class GrpcResponseMapper {
         .build();
   }
 
-  private GeneratedMessageV3 createDeployResourceResponse() {
+  private GeneratedMessage createDeployResourceResponse() {
     final DeploymentRecord deployment = new DeploymentRecord();
     deployment.wrap(valueBufferView);
 
@@ -197,7 +197,7 @@ class GrpcResponseMapper {
     return builder.build();
   }
 
-  private GeneratedMessageV3 evaluateDecisionResponse() {
+  private GeneratedMessage evaluateDecisionResponse() {
     final DecisionEvaluationRecord evaluationRecord = new DecisionEvaluationRecord();
     evaluationRecord.wrap(valueBufferView);
 
@@ -265,7 +265,7 @@ class GrpcResponseMapper {
         .build();
   }
 
-  private GeneratedMessageV3 createProcessInstanceResponse() {
+  private GeneratedMessage createProcessInstanceResponse() {
     final ProcessInstanceCreationRecord processInstance = new ProcessInstanceCreationRecord();
     processInstance.wrap(valueBufferView);
 
@@ -277,7 +277,7 @@ class GrpcResponseMapper {
         .build();
   }
 
-  private GeneratedMessageV3 createProcessInstanceWithResultResponse() {
+  private GeneratedMessage createProcessInstanceWithResultResponse() {
     final ProcessInstanceResultRecord processInstanceResult = new ProcessInstanceResultRecord();
     processInstanceResult.wrap(valueBufferView);
 
@@ -290,44 +290,44 @@ class GrpcResponseMapper {
         .build();
   }
 
-  private GeneratedMessageV3 createCancelInstanceResponse() {
+  private GeneratedMessage createCancelInstanceResponse() {
     return CancelProcessInstanceResponse.newBuilder().build();
   }
 
-  private GeneratedMessageV3 createModifyProcessInstanceResponse() {
+  private GeneratedMessage createModifyProcessInstanceResponse() {
     return ModifyProcessInstanceResponse.newBuilder().build();
   }
 
-  private GeneratedMessageV3 createMigrateProcessInstanceResponse() {
+  private GeneratedMessage createMigrateProcessInstanceResponse() {
     return MigrateProcessInstanceResponse.getDefaultInstance();
   }
 
-  private GeneratedMessageV3 createBroadcastSignalResponse() {
+  private GeneratedMessage createBroadcastSignalResponse() {
     final SignalRecord signal = new SignalRecord();
     signal.wrap(valueBufferView);
 
     return BroadcastSignalResponse.newBuilder().setKey(key).build();
   }
 
-  private GeneratedMessageV3 createResolveIncidentResponse() {
+  private GeneratedMessage createResolveIncidentResponse() {
     final IncidentRecord incident = new IncidentRecord();
     incident.wrap(valueBufferView);
 
     return ResolveIncidentResponse.newBuilder().build();
   }
 
-  private GeneratedMessageV3 createSetVariablesResponse() {
+  private GeneratedMessage createSetVariablesResponse() {
     final VariableDocumentRecord variableDocumentRecord = new VariableDocumentRecord();
     variableDocumentRecord.wrap(valueBufferView);
 
     return SetVariablesResponse.newBuilder().setKey(key).build();
   }
 
-  private GeneratedMessageV3 createMessageResponse() {
+  private GeneratedMessage createMessageResponse() {
     return PublishMessageResponse.newBuilder().setKey(key).build();
   }
 
-  private GeneratedMessageV3 createJobBatchResponse() {
+  private GeneratedMessage createJobBatchResponse() {
     final JobBatchRecord jobBatch = new JobBatchRecord();
     jobBatch.wrap(valueBufferView);
 
@@ -364,23 +364,23 @@ class GrpcResponseMapper {
         .build();
   }
 
-  private GeneratedMessageV3 createCompleteJobResponse() {
+  private GeneratedMessage createCompleteJobResponse() {
     return CompleteJobResponse.newBuilder().build();
   }
 
-  private GeneratedMessageV3 createFailJobResponse() {
+  private GeneratedMessage createFailJobResponse() {
     return FailJobResponse.newBuilder().build();
   }
 
-  private GeneratedMessageV3 createJobThrowErrorResponse() {
+  private GeneratedMessage createJobThrowErrorResponse() {
     return ThrowErrorResponse.newBuilder().build();
   }
 
-  private GeneratedMessageV3 createJobUpdateRetriesResponse() {
+  private GeneratedMessage createJobUpdateRetriesResponse() {
     return UpdateJobRetriesResponse.newBuilder().build();
   }
 
-  private GeneratedMessageV3 createJobUpdateTimeOutResponse() {
+  private GeneratedMessage createJobUpdateTimeOutResponse() {
     return UpdateJobTimeoutResponse.newBuilder().build();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcResponseWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcResponseWriter.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.process.test.engine;
 
-import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.GeneratedMessage;
 import com.google.rpc.Status;
 import io.camunda.zeebe.process.test.engine.GatewayRequestStore.Request;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -114,7 +114,7 @@ class GrpcResponseWriter implements CommandResponseWriter {
         requestListener.accept(intent);
       }
       final Request request = gatewayRequestStore.removeRequest(requestId);
-      final GeneratedMessageV3 response =
+      final GeneratedMessage response =
           responseMapper.map(request.requestType(), valueBufferView, key, intent);
       sendResponse(request, response);
     } catch (final Exception e) {
@@ -122,16 +122,16 @@ class GrpcResponseWriter implements CommandResponseWriter {
     }
   }
 
-  private void sendResponse(final Request request, final GeneratedMessageV3 response) {
-    final StreamObserver<GeneratedMessageV3> streamObserver =
-        (StreamObserver<GeneratedMessageV3>) request.responseObserver();
+  private void sendResponse(final Request request, final GeneratedMessage response) {
+    final StreamObserver<GeneratedMessage> streamObserver =
+        (StreamObserver<GeneratedMessage>) request.responseObserver();
     streamObserver.onNext(response);
     streamObserver.onCompleted();
   }
 
   private void sendError(final Request request, final Status error) {
-    final StreamObserver<GeneratedMessageV3> streamObserver =
-        (StreamObserver<GeneratedMessageV3>) request.responseObserver();
+    final StreamObserver<GeneratedMessage> streamObserver =
+        (StreamObserver<GeneratedMessage>) request.responseObserver();
     streamObserver.onError(StatusProto.toStatusException(error));
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryEngine.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryEngine.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.process.test.engine;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.process.test.api.RecordStreamSource;
@@ -95,8 +95,8 @@ public class InMemoryEngine implements ZeebeTestEngine {
   }
 
   @Override
-  public ZeebeClient createClient() {
-    return ZeebeClient.newClientBuilder()
+  public CamundaClient createClient() {
+    return CamundaClient.newClientBuilder()
         .applyEnvironmentVariableOverrides(false)
         .gatewayAddress(getGatewayAddress())
         .usePlaintext()
@@ -104,9 +104,9 @@ public class InMemoryEngine implements ZeebeTestEngine {
   }
 
   @Override
-  public ZeebeClient createClient(final ObjectMapper objectMapper) {
-    return ZeebeClient.newClientBuilder()
-        .withJsonMapper(new ZeebeObjectMapper(objectMapper))
+  public CamundaClient createClient(final ObjectMapper objectMapper) {
+    return CamundaClient.newClientBuilder()
+        .withJsonMapper(new CamundaObjectMapper(objectMapper))
         .applyEnvironmentVariableOverrides(false)
         .gatewayAddress(getGatewayAddress())
         .usePlaintext()

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
@@ -11,25 +11,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.util.concurrent.Uninterruptibles;
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.ZeebeFuture;
-import io.camunda.zeebe.client.api.command.ClientException;
-import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
-import io.camunda.zeebe.client.api.response.ActivatedJob;
-import io.camunda.zeebe.client.api.response.BroadcastSignalResponse;
-import io.camunda.zeebe.client.api.response.BrokerInfo;
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
-import io.camunda.zeebe.client.api.response.EvaluateDecisionResponse;
-import io.camunda.zeebe.client.api.response.Form;
-import io.camunda.zeebe.client.api.response.MigrateProcessInstanceResponse;
-import io.camunda.zeebe.client.api.response.PartitionBrokerHealth;
-import io.camunda.zeebe.client.api.response.PartitionBrokerRole;
-import io.camunda.zeebe.client.api.response.PartitionInfo;
-import io.camunda.zeebe.client.api.response.Process;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
-import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
-import io.camunda.zeebe.client.api.response.SetVariablesResponse;
-import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.ClientException;
+import io.camunda.client.api.response.ActivateJobsResponse;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.BroadcastSignalResponse;
+import io.camunda.client.api.response.BrokerInfo;
+import io.camunda.client.api.response.DeploymentEvent;
+import io.camunda.client.api.response.EvaluateDecisionResponse;
+import io.camunda.client.api.response.Form;
+import io.camunda.client.api.response.MigrateProcessInstanceResponse;
+import io.camunda.client.api.response.PartitionBrokerHealth;
+import io.camunda.client.api.response.PartitionBrokerRole;
+import io.camunda.client.api.response.PartitionInfo;
+import io.camunda.client.api.response.Process;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.response.ProcessInstanceResult;
+import io.camunda.client.api.response.SetVariablesResponse;
+import io.camunda.client.api.response.Topology;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.filters.JobRecordStreamFilter;
@@ -70,7 +70,7 @@ class EngineClientTest {
   private static final String DMN_RESOURCE = "dmn/drg-force-user.dmn";
 
   private ZeebeTestEngine zeebeEngine;
-  private ZeebeClient zeebeClient;
+  private CamundaClient zeebeClient;
 
   @BeforeEach
   void setupGrpcServer() {
@@ -125,8 +125,8 @@ class EngineClientTest {
   @Test
   void shouldUseGatewayAddressToBuildClient() {
     // given
-    final ZeebeClient client =
-        ZeebeClient.newClientBuilder()
+    final CamundaClient client =
+        CamundaClient.newClientBuilder()
             .applyEnvironmentVariableOverrides(false)
             .usePlaintext()
             .gatewayAddress(zeebeEngine.getGatewayAddress())
@@ -156,7 +156,7 @@ class EngineClientTest {
         .send()
         .join();
 
-    final ZeebeFuture<ProcessInstanceResult> processInstanceResult =
+    final CamundaFuture<ProcessInstanceResult> processInstanceResult =
         zeebeClient
             .newCreateInstanceCommand()
             .bpmnProcessId("process")
@@ -265,7 +265,7 @@ class EngineClientTest {
     // given
 
     // when
-    final ZeebeFuture<ProcessInstanceEvent> future =
+    final CamundaFuture<ProcessInstanceEvent> future =
         zeebeClient.newCreateInstanceCommand().bpmnProcessId("process").latestVersion().send();
 
     // then

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -52,7 +52,7 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-client-java</artifactId>
+      <artifactId>camunda-client-java</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/examples/src/test/java/io/camunda/zeebe/process/test/examples/PullRequestProcessTest.java
+++ b/examples/src/test/java/io/camunda/zeebe/process/test/examples/PullRequestProcessTest.java
@@ -18,11 +18,11 @@ package io.camunda.zeebe.process.test.examples;
 
 import static java.util.Collections.singletonMap;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.command.DeployResourceCommandStep1;
-import io.camunda.zeebe.client.api.response.ActivatedJob;
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
-import io.camunda.zeebe.client.api.response.PublishMessageResponse;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.DeployResourceCommandStep1;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.DeploymentEvent;
+import io.camunda.client.api.response.PublishMessageResponse;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.extension.ZeebeProcessTest;
@@ -63,7 +63,7 @@ public class PullRequestProcessTest {
   // injected by ZeebeProcessTest annotation
   private ZeebeTestEngine engine;
   // injected by ZeebeProcessTest annotation
-  private ZeebeClient client;
+  private CamundaClient client;
 
   @BeforeEach
   void deployProcesses() {
@@ -241,7 +241,7 @@ public class PullRequestProcessTest {
      due to time manipulation. This can be the cause of a flaky test.
 
      Note that by default, the time to live is set to 1 hour.
-     See {@code ZeebeClientBuilder#defaultTimeToLive}.
+     See {@code CamundaClientBuilder#defaultTimeToLive}.
     */
     final Duration timeToLive = Duration.ZERO;
 

--- a/extension-testcontainer/pom.xml
+++ b/extension-testcontainer/pom.xml
@@ -34,7 +34,7 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-client-java</artifactId>
+      <artifactId>camunda-client-java</artifactId>
     </dependency>
 
     <dependency>

--- a/extension-testcontainer/src/main/java/io.camunda.zeebe.process.test.extension.testcontainer/ContainerizedEngine.java
+++ b/extension-testcontainer/src/main/java/io.camunda.zeebe.process.test.extension.testcontainer/ContainerizedEngine.java
@@ -18,8 +18,8 @@ package io.camunda.zeebe.process.test.extension.testcontainer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.zeebe.process.test.api.RecordStreamSource;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.engine.protocol.EngineControlGrpc;
@@ -93,8 +93,8 @@ public class ContainerizedEngine implements ZeebeTestEngine {
   }
 
   @Override
-  public ZeebeClient createClient() {
-    return ZeebeClient.newClientBuilder()
+  public CamundaClient createClient() {
+    return CamundaClient.newClientBuilder()
         .applyEnvironmentVariableOverrides(false)
         .gatewayAddress(getGatewayAddress())
         .usePlaintext()
@@ -102,9 +102,9 @@ public class ContainerizedEngine implements ZeebeTestEngine {
   }
 
   @Override
-  public ZeebeClient createClient(final ObjectMapper objectMapper) {
-    return ZeebeClient.newClientBuilder()
-        .withJsonMapper(new ZeebeObjectMapper(objectMapper))
+  public CamundaClient createClient(final ObjectMapper objectMapper) {
+    return CamundaClient.newClientBuilder()
+        .withJsonMapper(new CamundaObjectMapper(objectMapper))
         .applyEnvironmentVariableOverrides(false)
         .gatewayAddress(getGatewayAddress())
         .usePlaintext()

--- a/extension-testcontainer/src/main/java/io.camunda.zeebe.process.test.extension.testcontainer/ZeebeProcessTest.java
+++ b/extension-testcontainer/src/main/java/io.camunda.zeebe.process.test.extension.testcontainer/ZeebeProcessTest.java
@@ -37,8 +37,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *         <li>ZeebeTestEngine - This is the engine that will run your process. It will provide some
  *             basic functionality to help you write your tests, such as waiting for an idle state
  *             and increasing the time.
- *         <li>ZeebeClient - This is the client that allows you to send commands to the engine, such
- *             as starting a process instance. The interface of this client is identical to the
+ *         <li>CamundaClient - This is the client that allows you to send commands to the engine,
+ *             such as starting a process instance. The interface of this client is identical to the
  *             interface you use to connect to a real Zeebe engine.
  *         <li>RecordStream - This gives you access to all the records that are processed by the
  *             engine. Assertions use the records for verifying expectations. This grants you the

--- a/extension-testcontainer/src/main/java/io.camunda.zeebe.process.test.extension.testcontainer/ZeebeProcessTestExtension.java
+++ b/extension-testcontainer/src/main/java/io.camunda.zeebe.process.test.extension.testcontainer/ZeebeProcessTestExtension.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.process.test.extension.testcontainer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.process.test.ObjectMapperConfig;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.filters.RecordStream;
@@ -85,7 +85,7 @@ public class ZeebeProcessTestExtension
 
     final ObjectMapper objectMapper = getObjectMapper(extensionContext);
     ObjectMapperConfig.initObjectMapper(objectMapper);
-    final ZeebeClient client = engine.createClient(objectMapper);
+    final CamundaClient client = engine.createClient(objectMapper);
     final RecordStream recordStream = RecordStream.of(new RecordStreamSourceImpl(engine));
     BpmnAssert.initRecordStream(recordStream);
 
@@ -103,7 +103,7 @@ public class ZeebeProcessTestExtension
   @Override
   public void afterEach(final ExtensionContext extensionContext) {
     final Object clientContent = getStore(extensionContext).get(KEY_ZEEBE_CLIENT);
-    final ZeebeClient client = (ZeebeClient) clientContent;
+    final CamundaClient client = (CamundaClient) clientContent;
     client.close();
 
     final Object engineContent = getStore(extensionContext.getParent().get()).get(KEY_ZEEBE_ENGINE);

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -42,7 +42,7 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-client-java</artifactId>
+      <artifactId>camunda-client-java</artifactId>
     </dependency>
 
     <dependency>

--- a/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTest.java
+++ b/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTest.java
@@ -28,8 +28,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *         <li>ZeebeTestEngine - This is the engine that will run your process. It will provide some
  *             basic functionality to help you write your tests, such as waiting for an idle state
  *             and increasing the time.
- *         <li>ZeebeClient - This is the client that allows you to send commands to the engine, such
- *             as starting a process instance. The interface of this client is identical to the
+ *         <li>CamundaClient - This is the client that allows you to send commands to the engine,
+ *             such as starting a process instance. The interface of this client is identical to the
  *             interface you use to connect to a real Zeebe engine.
  *         <li>RecordStream - This gives you access to all the records that are processed by the
  *             engine. Assertions use the records for verifying expectations. This grants you the

--- a/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtension.java
+++ b/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtension.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.process.test.extension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.process.test.ObjectMapperConfig;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
@@ -50,7 +50,7 @@ public class ZeebeProcessTestExtension
     engine.start();
     final var objectMapper = getObjectMapper(extensionContext);
     ObjectMapperConfig.initObjectMapper(objectMapper);
-    final ZeebeClient client = engine.createClient(objectMapper);
+    final CamundaClient client = engine.createClient(objectMapper);
     final RecordStream recordStream = RecordStream.of(engine.getRecordStreamSource());
 
     try {
@@ -77,7 +77,7 @@ public class ZeebeProcessTestExtension
     BpmnAssert.resetRecordStream();
 
     final Object clientContent = getStore(extensionContext).get(KEY_ZEEBE_CLIENT);
-    final ZeebeClient client = (ZeebeClient) clientContent;
+    final CamundaClient client = (CamundaClient) clientContent;
     client.close();
 
     final Object engineContent = getStore(extensionContext).get(KEY_ZEEBE_ENGINE);

--- a/filters/pom.xml
+++ b/filters/pom.xml
@@ -23,7 +23,7 @@
   <dependencies>
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-client-java</artifactId>
+      <artifactId>camunda-client-java</artifactId>
     </dependency>
 
     <dependency>

--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/ProcessRecordStreamFilter.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/ProcessRecordStreamFilter.java
@@ -16,7 +16,7 @@
 
 package io.camunda.zeebe.process.test.filters;
 
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
@@ -40,13 +40,13 @@ public class ProcessRecordStreamFilter {
     return stream.map(Record::getValue);
   }
 
-  public ProcessRecordStreamFilter withBpmnProcessId(String bpmnProcessId) {
+  public ProcessRecordStreamFilter withBpmnProcessId(final String bpmnProcessId) {
     return new ProcessRecordStreamFilter(
         stream.filter(
             record -> Objects.equals(record.getValue().getBpmnProcessId(), bpmnProcessId)));
   }
 
-  public ProcessRecordStreamFilter withDeployment(DeploymentEvent deployment) {
+  public ProcessRecordStreamFilter withDeployment(final DeploymentEvent deployment) {
     return new ProcessRecordStreamFilter(
         stream.filter(
             record ->

--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -139,6 +139,7 @@ public class RecordStreamLogger {
     valueTypeLoggers.put(ValueType.MAPPING, Object::toString);
     valueTypeLoggers.put(ValueType.REDISTRIBUTION, Object::toString);
     valueTypeLoggers.put(ValueType.IDENTITY_SETUP, Object::toString);
+    valueTypeLoggers.put(ValueType.RESOURCE, Object::toString);
   }
 
   public void log() {

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,12 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>camunda-security-core</artifactId>
+        <version>${dependency.zeebe.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>zeebe-msgpack-value</artifactId>
         <version>${dependency.zeebe.version}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -81,10 +81,10 @@
     <dependency.junit4.version>4.13.2</dependency.junit4.version>
     <dependency.micrometer.version>1.13.3</dependency.micrometer.version>
     <dependency.mockito.version>4.11.0</dependency.mockito.version>
-    <dependency.netty.version>4.1.110.Final</dependency.netty.version>
+    <dependency.netty.version>4.1.116.Final</dependency.netty.version>
     <dependency.osgi.version>6.0.0</dependency.osgi.version>
-    <dependency.proto.version>2.41.0</dependency.proto.version>
-    <dependency.protobuf.version>3.25.3</dependency.protobuf.version>
+    <dependency.proto.version>2.50.0</dependency.proto.version>
+    <dependency.protobuf.version>4.29.2</dependency.protobuf.version>
     <dependency.revapi.version>0.28.1</dependency.revapi.version>
     <dependency.scala.version>2.13.14</dependency.scala.version>
     <dependency.slf4j.version>2.0.13</dependency.slf4j.version>
@@ -119,10 +119,10 @@
 
     <skipChecks>false</skipChecks>
 
-    <!-- Note: needs to be aligned with the version used by io.camunda:zeebe-client-java -->
-    <version.grpc>1.68.0</version.grpc>
+    <!-- Note: needs to be aligned with the version used by io.camunda:camunda-client-java -->
+    <version.grpc>1.69.0</version.grpc>
     <version.java>21</version.java>
-    <version.protobuf>3.19.4</version.protobuf>
+    <version.protobuf>4.29.2</version.protobuf>
   </properties>
 
   <dependencyManagement>
@@ -193,7 +193,7 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
-        <artifactId>zeebe-client-java</artifactId>
+        <artifactId>camunda-client-java</artifactId>
         <version>${dependency.zeebe.version}</version>
       </dependency>
 

--- a/qa/abstracts/pom.xml
+++ b/qa/abstracts/pom.xml
@@ -50,7 +50,7 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-client-java</artifactId>
+      <artifactId>camunda-client-java</artifactId>
     </dependency>
 
     <dependency>

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractCustomObjectMapperTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractCustomObjectMapperTest.java
@@ -21,8 +21,8 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.qa.abstracts.util.Utilities;
@@ -52,7 +52,7 @@ public abstract class AbstractCustomObjectMapperTest {
   @Nested
   class HappyPathTests {
 
-    private ZeebeClient client;
+    private CamundaClient client;
     private ZeebeTestEngine engine;
 
     private final ObjectMapper objectMapper = configureObjectMapper();

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractDeploymentAssertTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractDeploymentAssertTest.java
@@ -17,8 +17,8 @@ package io.camunda.zeebe.process.test.qa.abstracts.assertions;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.assertions.ProcessAssert;
 import io.camunda.zeebe.process.test.qa.abstracts.util.Utilities;
@@ -36,7 +36,7 @@ public abstract class AbstractDeploymentAssertTest {
   @Nested
   class HappyPathTests {
 
-    private ZeebeClient client;
+    private CamundaClient client;
 
     @Test
     void testContainsProcessesById() {
@@ -103,7 +103,7 @@ public abstract class AbstractDeploymentAssertTest {
   @Nested
   class UnhappyPathTests {
 
-    private ZeebeClient client;
+    private CamundaClient client;
 
     @Test
     void testContainsProcessesByIdFailure() {

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractFormAssertTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractFormAssertTest.java
@@ -18,8 +18,8 @@ package io.camunda.zeebe.process.test.qa.abstracts.assertions;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.assertions.FormAssert;
@@ -38,7 +38,7 @@ public class AbstractFormAssertTest {
   @Nested
   class HappyPathTests {
 
-    private ZeebeClient client;
+    private CamundaClient client;
     private ZeebeTestEngine engine;
 
     @Test
@@ -103,7 +103,7 @@ public class AbstractFormAssertTest {
   @Nested
   class UnhappyPathTests {
 
-    private ZeebeClient client;
+    private CamundaClient client;
     private ZeebeTestEngine engine;
 
     @Test

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractIncidentAssertTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractIncidentAssertTest.java
@@ -17,10 +17,10 @@ package io.camunda.zeebe.process.test.qa.abstracts.assertions;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
-import io.camunda.zeebe.client.api.response.ActivatedJob;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivateJobsResponse;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.assertions.IncidentAssert;
@@ -46,7 +46,7 @@ public abstract class AbstractIncidentAssertTest {
   @Nested
   class HappyPathTests {
 
-    private ZeebeClient client;
+    private CamundaClient client;
     private ZeebeTestEngine engine;
 
     @Test
@@ -238,7 +238,7 @@ public abstract class AbstractIncidentAssertTest {
   @Nested
   class UnhappyPathTests {
 
-    private ZeebeClient client;
+    private CamundaClient client;
     private ZeebeTestEngine engine;
 
     @Test

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractJobAssertTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractJobAssertTest.java
@@ -19,9 +19,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.data.Offset.offset;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
-import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivateJobsResponse;
+import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.assertions.IncidentAssert;
@@ -46,7 +46,7 @@ public abstract class AbstractJobAssertTest {
   @Nested
   class HappyPathTests {
 
-    private ZeebeClient client;
+    private CamundaClient client;
     private ZeebeTestEngine engine;
 
     @Test
@@ -229,7 +229,7 @@ public abstract class AbstractJobAssertTest {
   @Nested
   class UnhappyPathTests {
 
-    private ZeebeClient client;
+    private CamundaClient client;
     private ZeebeTestEngine engine;
 
     @Test

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractMessageAssertTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractMessageAssertTest.java
@@ -17,9 +17,9 @@ package io.camunda.zeebe.process.test.qa.abstracts.assertions;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
-import io.camunda.zeebe.client.api.response.PublishMessageResponse;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.response.PublishMessageResponse;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.filters.RecordStream;
@@ -42,7 +42,7 @@ public abstract class AbstractMessageAssertTest {
   @Nested
   class HappyPathTests {
 
-    private ZeebeClient client;
+    private CamundaClient client;
     private ZeebeTestEngine engine;
 
     @Test
@@ -188,7 +188,7 @@ public abstract class AbstractMessageAssertTest {
   @Nested
   class UnhappyPathTests {
 
-    private ZeebeClient client;
+    private CamundaClient client;
     private ZeebeTestEngine engine;
 
     @Test

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractProcessAssertTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractProcessAssertTest.java
@@ -17,8 +17,8 @@ package io.camunda.zeebe.process.test.qa.abstracts.assertions;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.assertions.ProcessAssert;
@@ -36,7 +36,7 @@ public abstract class AbstractProcessAssertTest {
   @Nested
   class HappyPathTests {
 
-    private ZeebeClient client;
+    private CamundaClient client;
     private ZeebeTestEngine engine;
 
     @Test
@@ -139,7 +139,7 @@ public abstract class AbstractProcessAssertTest {
   @Nested
   class UnhappyPathTests {
 
-    private ZeebeClient client;
+    private CamundaClient client;
     private ZeebeTestEngine engine;
 
     @Test

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractProcessInstanceAssertTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/assertions/AbstractProcessInstanceAssertTest.java
@@ -20,8 +20,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.assertions.IncidentAssert;
@@ -59,7 +59,7 @@ public abstract class AbstractProcessInstanceAssertTest {
   @Nested
   class HappyPathTests {
 
-    private ZeebeClient client;
+    private CamundaClient client;
     private ZeebeTestEngine engine;
 
     @Test
@@ -623,7 +623,7 @@ public abstract class AbstractProcessInstanceAssertTest {
   @Nested
   class UnhappyPathTests {
 
-    private ZeebeClient client;
+    private CamundaClient client;
     private ZeebeTestEngine engine;
 
     @Test
@@ -1395,7 +1395,7 @@ public abstract class AbstractProcessInstanceAssertTest {
   @Nested
   class RegressionTests {
 
-    private ZeebeClient client;
+    private CamundaClient client;
     private ZeebeTestEngine engine;
 
     @Test // regression test for #78

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/injection/AbstractInheritanceInjectionTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/injection/AbstractInheritanceInjectionTest.java
@@ -18,13 +18,13 @@ package io.camunda.zeebe.process.test.qa.abstracts.injection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Topology;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import org.junit.jupiter.api.Test;
 
 public abstract class AbstractInheritanceInjectionTest {
-  protected ZeebeClient client;
+  protected CamundaClient client;
   protected ZeebeTestEngine engine;
 
   @Test

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/inspections/AbstractFormInspectionsTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/inspections/AbstractFormInspectionsTest.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.process.test.qa.abstracts.inspections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.inspections.FormInspectionsUtility;
 import io.camunda.zeebe.process.test.qa.abstracts.util.Utilities;
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 
 public abstract class AbstractFormInspectionsTest {
 
-  private ZeebeClient client;
+  private CamundaClient client;
   private ZeebeTestEngine engine;
 
   @Test

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/inspections/AbstractProcessEventInspectionsTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/inspections/AbstractProcessEventInspectionsTest.java
@@ -15,8 +15,8 @@
  */
 package io.camunda.zeebe.process.test.qa.abstracts.inspections;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.inspections.InspectionUtility;
@@ -102,7 +102,7 @@ public abstract class AbstractProcessEventInspectionsTest {
     Assertions.assertThat(processInstance).isEmpty();
   }
 
-  public abstract ZeebeClient getClient();
+  public abstract CamundaClient getClient();
 
   public abstract ZeebeTestEngine getEngine();
 }

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/inspections/AbstractProcessInspectionsTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/inspections/AbstractProcessInspectionsTest.java
@@ -20,8 +20,8 @@ import static io.camunda.zeebe.process.test.inspections.ProcessDefinitionInspect
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.qa.abstracts.util.Utilities;
 import io.camunda.zeebe.process.test.qa.abstracts.util.Utilities.ProcessPackNamedElements;
@@ -83,7 +83,7 @@ public abstract class AbstractProcessInspectionsTest {
         .isInstanceOf(AssertionError.class);
   }
 
-  public abstract ZeebeClient getClient();
+  public abstract CamundaClient getClient();
 
   public abstract ZeebeTestEngine getEngine();
 }

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/inspections/AbstractProcessInstanceInspectionsTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/inspections/AbstractProcessInstanceInspectionsTest.java
@@ -15,8 +15,8 @@
  */
 package io.camunda.zeebe.process.test.qa.abstracts.inspections;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.inspections.InspectionUtility;
@@ -79,7 +79,7 @@ public abstract class AbstractProcessInstanceInspectionsTest {
     Assertions.assertThat(firstProcessInstance).isEmpty();
   }
 
-  public abstract ZeebeClient getClient();
+  public abstract CamundaClient getClient();
 
   public abstract ZeebeTestEngine getEngine();
 }

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/jobs/AbstractTimerTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/jobs/AbstractTimerTest.java
@@ -18,9 +18,9 @@ package io.camunda.zeebe.process.test.qa.abstracts.jobs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivateJobsResponse;
+import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.filters.RecordStream;
@@ -47,7 +47,7 @@ public abstract class AbstractTimerTest {
   private static final String RESOURCE = "test_timer_events.bpmn";
   private static final String PROCESS_ID = "Process_Timer_Test_01";
 
-  private ZeebeClient client;
+  private CamundaClient client;
   private ZeebeTestEngine engine;
   private RecordStream recordStream;
 

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/mapper/AbstractMapperNotSerializationDeserializationTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/mapper/AbstractMapperNotSerializationDeserializationTest.java
@@ -16,16 +16,16 @@
 
 package io.camunda.zeebe.process.test.qa.abstracts.mapper;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.JsonMapper;
-import io.camunda.zeebe.client.api.command.InternalClientException;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.InternalClientException;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public abstract class AbstractMapperNotSerializationDeserializationTest {
-  protected ZeebeClient client;
+  protected CamundaClient client;
   protected ZeebeTestEngine engine;
 
   @Test

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/mapper/AbstractMapperSerializationDeserializationTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/mapper/AbstractMapperSerializationDeserializationTest.java
@@ -21,14 +21,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.JsonMapper;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
 public abstract class AbstractMapperSerializationDeserializationTest {
-  protected ZeebeClient client;
+  protected CamundaClient client;
   protected ZeebeTestEngine engine;
   protected ObjectMapper mapper = configureObjectMapper();
 

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/multithread/AbstractMultiThreadTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/multithread/AbstractMultiThreadTest.java
@@ -19,8 +19,8 @@ import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
 import static io.camunda.zeebe.process.test.qa.abstracts.util.Utilities.deployResource;
 import static io.camunda.zeebe.process.test.qa.abstracts.util.Utilities.startProcessInstance;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.filters.RecordStream;
@@ -75,7 +75,7 @@ public abstract class AbstractMultiThreadTest {
     }
   }
 
-  public abstract ZeebeClient getClient();
+  public abstract CamundaClient getClient();
 
   public abstract ZeebeTestEngine getEngine();
 

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/multithread/AbstractWorkerTest.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/multithread/AbstractWorkerTest.java
@@ -17,8 +17,8 @@ package io.camunda.zeebe.process.test.qa.abstracts.multithread;
 
 import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceResult;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.qa.abstracts.util.Utilities;
 import io.camunda.zeebe.process.test.qa.abstracts.util.Utilities.ProcessPackLoopingServiceTask;
@@ -55,7 +55,7 @@ public abstract class AbstractWorkerTest {
         .isCompleted();
   }
 
-  public abstract ZeebeClient getClient();
+  public abstract CamundaClient getClient();
 
   public abstract ZeebeTestEngine getEngine();
 }

--- a/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/util/Utilities.java
+++ b/qa/abstracts/src/main/java/io/camunda/zeebe/process/test/qa/abstracts/util/Utilities.java
@@ -15,13 +15,13 @@
  */
 package io.camunda.zeebe.process.test.qa.abstracts.util;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.command.DeployResourceCommandStep1;
-import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
-import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
-import io.camunda.zeebe.client.api.response.PublishMessageResponse;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.DeployResourceCommandStep1;
+import io.camunda.client.api.response.ActivateJobsResponse;
+import io.camunda.client.api.response.DeploymentEvent;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.response.ProcessInstanceResult;
+import io.camunda.client.api.response.PublishMessageResponse;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.filters.RecordStream;
 import io.camunda.zeebe.process.test.filters.StreamFilter;
@@ -43,12 +43,12 @@ public class Utilities {
 
   private static final Logger LOG = LoggerFactory.getLogger(Utilities.class);
 
-  public static DeploymentEvent deployResource(final ZeebeClient client, final String resource) {
+  public static DeploymentEvent deployResource(final CamundaClient client, final String resource) {
     return deployResources(client, resource);
   }
 
   public static DeploymentEvent deployResources(
-      final ZeebeClient client, final String... resources) {
+      final CamundaClient client, final String... resources) {
     final DeployResourceCommandStep1 commandStep1 = client.newDeployResourceCommand();
 
     DeployResourceCommandStep1.DeployResourceCommandStep2 commandStep2 = null;
@@ -64,14 +64,14 @@ public class Utilities {
   }
 
   public static ProcessInstanceEvent startProcessInstance(
-      final ZeebeTestEngine engine, final ZeebeClient client, final String processId)
+      final ZeebeTestEngine engine, final CamundaClient client, final String processId)
       throws InterruptedException, TimeoutException {
     return startProcessInstance(engine, client, processId, new HashMap<>());
   }
 
   public static ProcessInstanceEvent startProcessInstance(
       final ZeebeTestEngine engine,
-      final ZeebeClient client,
+      final CamundaClient client,
       final String processId,
       final Map<String, Object> variables)
       throws InterruptedException, TimeoutException {
@@ -89,7 +89,7 @@ public class Utilities {
 
   public static ProcessInstanceResult startProcessInstanceWithResult(
       final ZeebeTestEngine engine,
-      final ZeebeClient client,
+      final CamundaClient client,
       final String processId,
       final Map<String, Object> variables)
       throws InterruptedException, TimeoutException {
@@ -108,7 +108,7 @@ public class Utilities {
   }
 
   public static ActivateJobsResponse activateSingleJob(
-      final ZeebeClient client, final String jobType) {
+      final CamundaClient client, final String jobType) {
     return client.newActivateJobsCommand().jobType(jobType).maxJobsToActivate(1).send().join();
   }
 
@@ -127,7 +127,7 @@ public class Utilities {
    * afterward to ensure that the message publication is processed.
    *
    * <p>The message is published without a time to live and without variables. If you need to set a
-   * time to live or variables, use {@link #sendMessage(ZeebeTestEngine, ZeebeClient, String,
+   * time to live or variables, use {@link #sendMessage(ZeebeTestEngine, CamundaClient, String,
    * String, Duration, Map)} instead.
    *
    * @param engine the engine to wait for to be idle
@@ -141,7 +141,7 @@ public class Utilities {
    */
   public static PublishMessageResponse sendMessage(
       final ZeebeTestEngine engine,
-      final ZeebeClient client,
+      final CamundaClient client,
       final String messageName,
       final String correlationKey)
       throws InterruptedException, TimeoutException {
@@ -154,7 +154,7 @@ public class Utilities {
    * for the engine to be idle afterward to ensure that the message publication is processed.
    *
    * <p>If you do not need to set a time to live or variables, use {@link
-   * #sendMessage(ZeebeTestEngine, ZeebeClient, String, String)} instead.
+   * #sendMessage(ZeebeTestEngine, CamundaClient, String, String)} instead.
    *
    * @param engine the engine to wait for to be idle
    * @param client the client to use to publish the message
@@ -169,7 +169,7 @@ public class Utilities {
    */
   public static PublishMessageResponse sendMessage(
       final ZeebeTestEngine engine,
-      final ZeebeClient client,
+      final CamundaClient client,
       final String messageName,
       final String correlationKey,
       final Duration timeToLive,
@@ -226,7 +226,7 @@ public class Utilities {
   }
 
   public static void completeTask(
-      final ZeebeTestEngine engine, final ZeebeClient client, final String taskId)
+      final ZeebeTestEngine engine, final CamundaClient client, final String taskId)
       throws InterruptedException, TimeoutException {
     final List<Record<JobRecordValue>> records =
         StreamFilter.jobRecords(RecordStream.of(engine.getRecordStreamSource()))
@@ -255,7 +255,7 @@ public class Utilities {
 
   public static void throwErrorCommand(
       final ZeebeTestEngine engine,
-      final ZeebeClient client,
+      final CamundaClient client,
       final long key,
       final String errorCode,
       final String errorMessage)

--- a/qa/embedded/pom.xml
+++ b/qa/embedded/pom.xml
@@ -63,7 +63,7 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-client-java</artifactId>
+      <artifactId>camunda-client-java</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/qa/embedded/src/test/java/io/camunda/zeebe/process/test/qa/embedded/inspections/ProcessEventInspectionsTest.java
+++ b/qa/embedded/src/test/java/io/camunda/zeebe/process/test/qa/embedded/inspections/ProcessEventInspectionsTest.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.process.test.qa.embedded.inspections;
 
-import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.extension.ZeebeProcessTest;
 import io.camunda.zeebe.process.test.qa.abstracts.inspections.AbstractProcessEventInspectionsTest;
@@ -23,11 +23,11 @@ import io.camunda.zeebe.process.test.qa.abstracts.inspections.AbstractProcessEve
 @ZeebeProcessTest
 class ProcessEventInspectionsTest extends AbstractProcessEventInspectionsTest {
 
-  private ZeebeClient client;
+  private CamundaClient client;
   private ZeebeTestEngine engine;
 
   @Override
-  public ZeebeClient getClient() {
+  public CamundaClient getClient() {
     return client;
   }
 

--- a/qa/embedded/src/test/java/io/camunda/zeebe/process/test/qa/embedded/inspections/ProcessInspectionsTest.java
+++ b/qa/embedded/src/test/java/io/camunda/zeebe/process/test/qa/embedded/inspections/ProcessInspectionsTest.java
@@ -16,18 +16,18 @@
 
 package io.camunda.zeebe.process.test.qa.embedded.inspections;
 
-import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.extension.ZeebeProcessTest;
 import io.camunda.zeebe.process.test.qa.abstracts.inspections.AbstractProcessInspectionsTest;
 
 @ZeebeProcessTest
 public class ProcessInspectionsTest extends AbstractProcessInspectionsTest {
-  private ZeebeClient client;
+  private CamundaClient client;
   private ZeebeTestEngine engine;
 
   @Override
-  public ZeebeClient getClient() {
+  public CamundaClient getClient() {
     return client;
   }
 

--- a/qa/embedded/src/test/java/io/camunda/zeebe/process/test/qa/embedded/inspections/ProcessInstanceInspectionsTest.java
+++ b/qa/embedded/src/test/java/io/camunda/zeebe/process/test/qa/embedded/inspections/ProcessInstanceInspectionsTest.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.process.test.qa.embedded.inspections;
 
-import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.extension.ZeebeProcessTest;
 import io.camunda.zeebe.process.test.qa.abstracts.inspections.AbstractProcessInstanceInspectionsTest;
@@ -23,11 +23,11 @@ import io.camunda.zeebe.process.test.qa.abstracts.inspections.AbstractProcessIns
 @ZeebeProcessTest
 class ProcessInstanceInspectionsTest extends AbstractProcessInstanceInspectionsTest {
 
-  private ZeebeClient client;
+  private CamundaClient client;
   private ZeebeTestEngine engine;
 
   @Override
-  public ZeebeClient getClient() {
+  public CamundaClient getClient() {
     return client;
   }
 

--- a/qa/embedded/src/test/java/io/camunda/zeebe/process/test/qa/embedded/multithread/MultiThreadTest.java
+++ b/qa/embedded/src/test/java/io/camunda/zeebe/process/test/qa/embedded/multithread/MultiThreadTest.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.process.test.qa.embedded.multithread;
 
-import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.extension.ZeebeProcessTest;
 import io.camunda.zeebe.process.test.filters.RecordStream;
@@ -25,11 +25,11 @@ import io.camunda.zeebe.process.test.qa.abstracts.multithread.AbstractMultiThrea
 class MultiThreadTest extends AbstractMultiThreadTest {
 
   private ZeebeTestEngine engine;
-  private ZeebeClient client;
+  private CamundaClient client;
   private RecordStream recordStream;
 
   @Override
-  public ZeebeClient getClient() {
+  public CamundaClient getClient() {
     return client;
   }
 

--- a/qa/embedded/src/test/java/io/camunda/zeebe/process/test/qa/embedded/multithread/WorkerTest.java
+++ b/qa/embedded/src/test/java/io/camunda/zeebe/process/test/qa/embedded/multithread/WorkerTest.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.process.test.qa.embedded.multithread;
 
-import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.extension.ZeebeProcessTest;
 import io.camunda.zeebe.process.test.qa.abstracts.multithread.AbstractWorkerTest;
@@ -23,11 +23,11 @@ import io.camunda.zeebe.process.test.qa.abstracts.multithread.AbstractWorkerTest
 @ZeebeProcessTest
 class WorkerTest extends AbstractWorkerTest {
 
-  private ZeebeClient client;
+  private CamundaClient client;
   private ZeebeTestEngine engine;
 
   @Override
-  public ZeebeClient getClient() {
+  public CamundaClient getClient() {
     return client;
   }
 

--- a/qa/testcontainers/pom.xml
+++ b/qa/testcontainers/pom.xml
@@ -48,7 +48,7 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-client-java</artifactId>
+      <artifactId>camunda-client-java</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/qa/testcontainers/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/inspections/ProcessEventInspectionsTest.java
+++ b/qa/testcontainers/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/inspections/ProcessEventInspectionsTest.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.process.test.qa.testcontainer.inspections;
 
-import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.extension.testcontainer.ZeebeProcessTest;
 import io.camunda.zeebe.process.test.qa.abstracts.inspections.AbstractProcessEventInspectionsTest;
@@ -23,11 +23,11 @@ import io.camunda.zeebe.process.test.qa.abstracts.inspections.AbstractProcessEve
 @ZeebeProcessTest
 class ProcessEventInspectionsTest extends AbstractProcessEventInspectionsTest {
 
-  private ZeebeClient client;
+  private CamundaClient client;
   private ZeebeTestEngine engine;
 
   @Override
-  public ZeebeClient getClient() {
+  public CamundaClient getClient() {
     return client;
   }
 

--- a/qa/testcontainers/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/inspections/ProcessInspectionsTest.java
+++ b/qa/testcontainers/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/inspections/ProcessInspectionsTest.java
@@ -16,18 +16,18 @@
 
 package io.camunda.zeebe.process.test.qa.testcontainer.inspections;
 
-import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.extension.testcontainer.ZeebeProcessTest;
 import io.camunda.zeebe.process.test.qa.abstracts.inspections.AbstractProcessInspectionsTest;
 
 @ZeebeProcessTest
 public class ProcessInspectionsTest extends AbstractProcessInspectionsTest {
-  private ZeebeClient client;
+  private CamundaClient client;
   private ZeebeTestEngine engine;
 
   @Override
-  public ZeebeClient getClient() {
+  public CamundaClient getClient() {
     return client;
   }
 

--- a/qa/testcontainers/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/inspections/ProcessInstanceInspectionsTest.java
+++ b/qa/testcontainers/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/inspections/ProcessInstanceInspectionsTest.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.process.test.qa.testcontainer.inspections;
 
-import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.extension.testcontainer.ZeebeProcessTest;
 import io.camunda.zeebe.process.test.qa.abstracts.inspections.AbstractProcessInstanceInspectionsTest;
@@ -23,11 +23,11 @@ import io.camunda.zeebe.process.test.qa.abstracts.inspections.AbstractProcessIns
 @ZeebeProcessTest
 class ProcessInstanceInspectionsTest extends AbstractProcessInstanceInspectionsTest {
 
-  private ZeebeClient client;
+  private CamundaClient client;
   private ZeebeTestEngine engine;
 
   @Override
-  public ZeebeClient getClient() {
+  public CamundaClient getClient() {
     return client;
   }
 

--- a/qa/testcontainers/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/multithread/MultiThreadTest.java
+++ b/qa/testcontainers/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/multithread/MultiThreadTest.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.process.test.qa.testcontainer.multithread;
 
-import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.extension.testcontainer.ZeebeProcessTest;
 import io.camunda.zeebe.process.test.filters.RecordStream;
@@ -25,11 +25,11 @@ import io.camunda.zeebe.process.test.qa.abstracts.multithread.AbstractMultiThrea
 class MultiThreadTest extends AbstractMultiThreadTest {
 
   private ZeebeTestEngine engine;
-  private ZeebeClient client;
+  private CamundaClient client;
   private RecordStream recordStream;
 
   @Override
-  public ZeebeClient getClient() {
+  public CamundaClient getClient() {
     return client;
   }
 

--- a/qa/testcontainers/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/multithread/WorkerTest.java
+++ b/qa/testcontainers/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/multithread/WorkerTest.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.process.test.qa.testcontainer.multithread;
 
-import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.extension.testcontainer.ZeebeProcessTest;
 import io.camunda.zeebe.process.test.qa.abstracts.multithread.AbstractWorkerTest;
@@ -23,11 +23,11 @@ import io.camunda.zeebe.process.test.qa.abstracts.multithread.AbstractWorkerTest
 @ZeebeProcessTest
 class WorkerTest extends AbstractWorkerTest {
 
-  private ZeebeClient client;
+  private CamundaClient client;
   private ZeebeTestEngine engine;
 
   @Override
-  public ZeebeClient getClient() {
+  public CamundaClient getClient() {
     return client;
   }
 


### PR DESCRIPTION
## Description

This PR migrates ZPT to `camunda-client-java`, thereby fixing the broken build. Most of it consists of just changing the types to their new equivalent `CamundaClient` types. The rest is Revapi configuration to allow for breaking changes.

To account for protocol differences/changes, Protobuf, Netty, and gRPC were all bumped as well.

## Definition of Done

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually

Documentation:
* [x] Javadoc has been written
* [x] The documentation is updated
