### PR TITLE
[Backport main] ci: revapi ignored changes for all 8.7 minor versions

### DIFF
--- a/assertions/ignored-changes.json
+++ b/assertions/ignored-changes.json
@@ -6,74 +6,86 @@
       "differences": [
         {
           "ignore": true,
+          "regex": true,
           "code": "java.method.returnTypeChanged",
-          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0-SNAPSHOT",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.*",
           "justification": "Migration from zeebe-client-java to camunda-client-java"
         },
         {
           "ignore": true,
+          "regex": true,
           "code": "java.method.parameterTypeParameterChanged",
-          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0-SNAPSHOT",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.*",
           "justification": "Migration from zeebe-client-java to camunda-client-java"
         },
         {
           "ignore": true,
+          "regex": true,
           "code": "java.method.parameterTypeChanged",
-          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0-SNAPSHOT",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.*",
           "justification": "Migration from zeebe-client-java to camunda-client-java"
         },
         {
           "ignore": true,
+          "regex": true,
           "code": "java.field.typeChanged",
-          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0-SNAPSHOT",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.*",
           "justification": "Migration from zeebe-client-java to camunda-client-java"
         },
         {
           "ignore": true,
+          "regex": true,
           "code": "java.class.noLongerImplementsInterface",
-          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0-SNAPSHOT",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.*",
           "justification": "Migration from zeebe-client-java to camunda-client-java"
         },
         {
           "ignore": true,
+          "regex": true,
           "code": "java.class.superTypeTypeParametersChanged",
-          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0-SNAPSHOT",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.*",
           "justification": "Migration from zeebe-client-java to camunda-client-java"
         },
         {
           "ignore": true,
+          "regex": true,
           "code": "java.method.returnTypeChanged",
-          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.*",
           "justification": "Migration from zeebe-client-java to camunda-client-java"
         },
         {
           "ignore": true,
+          "regex": true,
           "code": "java.method.parameterTypeParameterChanged",
-          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.*",
           "justification": "Migration from zeebe-client-java to camunda-client-java"
         },
         {
           "ignore": true,
+          "regex": true,
           "code": "java.method.parameterTypeChanged",
-          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.*",
           "justification": "Migration from zeebe-client-java to camunda-client-java"
         },
         {
           "ignore": true,
+          "regex": true,
           "code": "java.field.typeChanged",
-          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.*",
           "justification": "Migration from zeebe-client-java to camunda-client-java"
         },
         {
           "ignore": true,
+          "regex": true,
           "code": "java.class.noLongerImplementsInterface",
-          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.*",
           "justification": "Migration from zeebe-client-java to camunda-client-java"
         },
         {
           "ignore": true,
+          "regex": true,
           "code": "java.class.superTypeTypeParametersChanged",
-          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.0",
+          "newArchive": "io.camunda:zeebe-process-test-assertions:jar:8.7.*",
           "justification": "Migration from zeebe-client-java to camunda-client-java"
         }
       ]


### PR DESCRIPTION
# Description
Backport of #1295 to `main`.

relates to 