### PR TITLE
deps: downgrade model due to JDK requirements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency.assertj.version>3.25.3</dependency.assertj.version>
     <dependency.awaitility.version>4.2.2</dependency.awaitility.version>
     <dependency.bytebuddy.version>1.14.16</dependency.bytebuddy.version>
-    <dependency.camundamodel.version>7.22.0</dependency.camundamodel.version>
+    <dependency.camundamodel.version>7.19.0</dependency.camundamodel.version>
     <dependency.classgraph.version>4.8.174</dependency.classgraph.version>
     <dependency.commons.version>3.14.0</dependency.commons.version>
     <dependency.errorprone.version>2.29.0</dependency.errorprone.version>


### PR DESCRIPTION
## Description

Downgrades `camunda-xml-model` to 7.19.0, as 7.22.0 targets JDK 11, and we depend on it for the `assertions` module, which targets JDK 8.

## Related issues

related to https://github.com/camunda/camunda/issues/26459