### PR TITLE
ci: revert nexus.snapshot.repository.id change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/</nexus.release.repository>
     <nexus.release.repository.id>camunda-nexus</nexus.release.repository.id>
     <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</nexus.snapshot.repository>
-    <nexus.snapshot.repository.id>camunda-nexus-snapshots</nexus.snapshot.repository.id>
+    <nexus.snapshot.repository.id>camunda-nexus</nexus.snapshot.repository.id>
 
     <plugin.version.dependency>3.6.1</plugin.version.dependency>
     <plugin.version.flatten>1.6.0</plugin.version.flatten>
@@ -486,7 +486,7 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>${nexus.release.repository.id}</id>
+      <id>${nexus.release.repository.id}-release</id>
       <url>${nexus.release.repository}</url>
     </repository>
     <repository>


### PR DESCRIPTION
## Description

The change of the id caused issues on artifact deploy, as it needs to match the id of the repo from the maven settings to use the correct credentials.

It previously broke because of https://github.com/camunda/zeebe-process-test/pull/1286
