### PR TITLE
build: run TC tests with Java 21

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -113,18 +113,9 @@ jobs:
           IMAGE_NAME_KEY: container.image.name
           IMAGE_TAG_KEY: container.image.tag
 
-      - name: Downgrade Java environment
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 8
-          cache: maven
-
-      # Deleting .mvn/jvm.config is a workaround for JDK8, which does not support the --add-exports options
       - name: Build
         id: build
         run: |
-          rm .mvn/jvm.config
           mvn clean -B -U -pl ":zeebe-process-test-qa-testcontainers" -P !localBuild -am "-Dsurefire.rerunFailingTestsCount=5" install -DskipChecks
 
       - name: Archive Test Results


### PR DESCRIPTION
## Description

We specify the release version to be Java 8 when running the tests, which ensures that we will catch issues where use APIs > JDK 8, or syntax that is unsupported on JDK 8, while still allowing us to use a build environment (including plugins) for greater versions.

The one downside is we won't detect anymore if we pull in transitive dependencies > JDK 8, but this should be detected separately.