### PR TITLE
[Backport stable/8.3] build(deps): Bump actions/upload-artifact from 3 to 4

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,7 +55,7 @@ jobs:
         run: mvn -B -U -pl "-:zeebe-process-test-qa-testcontainers" -P !localBuild "-Dsurefire.rerunFailingTestsCount=5" clean install
 
       - name: Archive Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Unit Test Results ${{ matrix.os }}
@@ -114,7 +114,7 @@ jobs:
           mvn -B -U -pl ":zeebe-process-test-qa-testcontainers" -P !localBuild -am "-Dsurefire.rerunFailingTestsCount=5" install -DskipChecks
 
       - name: Archive Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Unit Test Results Testcontainers
@@ -141,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Event File
           path: ${{ github.event_path }}

--- a/.github/workflows/snapshot-test.yml
+++ b/.github/workflows/snapshot-test.yml
@@ -33,7 +33,7 @@ jobs:
           mvn -B -U -pl "-:zeebe-process-test-qa-testcontainers" -P !localBuild "-Dsurefire.rerunFailingTestsCount=5" -Ddependency.zeebe.version=$NEW_ZEEBE_VERSION clean install
 
       - name: Archive Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Unit Test Results Against Zeebe Snapshot


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/zeebe-process-test/pull/1010 as the v3 action is not supported anymore, see https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/