### PR TITLE
deps: align camunda model version to 7.22 with camunda/camunda

### DIFF
--- a/assertions/pom.xml
+++ b/assertions/pom.xml
@@ -18,8 +18,26 @@
   <description>Assertions for verifying the state of a process.</description>
 
   <properties>
+    <!-- needed as newer model releases don't support jdk 8 -->
+    <dependency.camundamodel.version>7.19.0</dependency.camundamodel.version>
     <version.java>8</version.java>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.camunda.bpm.model</groupId>
+        <artifactId>camunda-dmn-model</artifactId>
+        <version>${dependency.camundamodel.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.camunda.bpm.model</groupId>
+        <artifactId>camunda-xml-model</artifactId>
+        <version>${dependency.camundamodel.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency.assertj.version>3.25.3</dependency.assertj.version>
     <dependency.awaitility.version>4.2.2</dependency.awaitility.version>
     <dependency.bytebuddy.version>1.14.12</dependency.bytebuddy.version>
-    <dependency.camundamodel.version>7.19.0</dependency.camundamodel.version>
+    <dependency.camundamodel.version>7.22.0</dependency.camundamodel.version>
     <dependency.classgraph.version>4.8.179</dependency.classgraph.version>
     <dependency.commons.version>3.14.0</dependency.commons.version>
     <dependency.errorprone.version>2.26.1</dependency.errorprone.version>

--- a/qa/testcontainers/pom.xml
+++ b/qa/testcontainers/pom.xml
@@ -12,8 +12,26 @@
   <name>Zeebe Process Test QA Testcontainers</name>
 
   <properties>
+    <!-- needed as newer model releases don't support jdk 8 -->
+    <dependency.camundamodel.version>7.19.0</dependency.camundamodel.version>
     <version.java>8</version.java>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.camunda.bpm.model</groupId>
+        <artifactId>camunda-dmn-model</artifactId>
+        <version>${dependency.camundamodel.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.camunda.bpm.model</groupId>
+        <artifactId>camunda-xml-model</artifactId>
+        <version>${dependency.camundamodel.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
## Description

Originally a backport of #1494 but turned out there was a maven setup issue, causing it to get merged while actually it should have failed CI see https://github.com/camunda/zeebe-process-test/pull/1500#issuecomment-2662773622 .

## Related issues

closes #1493