### PR TITLE
Fix stable/8.7 CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
     <dependency.scala.version>2.13.16</dependency.scala.version>
     <dependency.slf4j.version>2.0.16</dependency.slf4j.version>
     <dependency.snakeyaml.version>2.2</dependency.snakeyaml.version>
+    <dependency.spring-boot.version>3.4.2</dependency.spring-boot.version>
     <dependency.spring.version>6.1.14</dependency.spring.version>
     <dependency.testcontainers.version>1.19.8</dependency.testcontainers.version>
     <dependency.zeebe.version>8.7.0-SNAPSHOT</dependency.zeebe.version>
@@ -485,6 +486,14 @@
         <groupId>org.springframework</groupId>
         <artifactId>spring-core</artifactId>
         <version>${dependency.spring.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${dependency.spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,6 @@
     <dependency.feel.version>1.17.7</dependency.feel.version>
     <dependency.findbugs.version>3.0.2</dependency.findbugs.version>
     <dependency.guava.version>33.2.0-jre</dependency.guava.version>
-    <dependency.httpcore5.version>5.2.5</dependency.httpcore5.version>
     <dependency.immutables.version>2.10.1</dependency.immutables.version>
     <dependency.jackson.version>2.17.0</dependency.jackson.version>
     <dependency.javax.version>1.3.2</dependency.javax.version>
@@ -428,11 +427,6 @@
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
         <version>${dependency.bytebuddy.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents.core5</groupId>
-        <artifactId>httpcore5</artifactId>
-        <version>${dependency.httpcore5.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jetbrains</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,6 @@
     <dependency.slf4j.version>2.0.16</dependency.slf4j.version>
     <dependency.snakeyaml.version>2.2</dependency.snakeyaml.version>
     <dependency.spring-boot.version>3.4.2</dependency.spring-boot.version>
-    <dependency.spring.version>6.1.14</dependency.spring.version>
     <dependency.testcontainers.version>1.19.8</dependency.testcontainers.version>
     <dependency.zeebe.version>8.7.0-SNAPSHOT</dependency.zeebe.version>
 
@@ -468,18 +467,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${dependency.commons.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-context</artifactId>
-        <version>${dependency.spring.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-core</artifactId>
-        <version>${dependency.spring.version}</version>
       </dependency>
 
       <dependency>

--- a/spring-test/pom.xml
+++ b/spring-test/pom.xml
@@ -22,21 +22,7 @@
 
   <properties>
     <plugin.version.license>4.6</plugin.version.license>
-    <version.spring-boot>3.3.7</version.spring-boot>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <build>
     <plugins>


### PR DESCRIPTION
## Description

This fixes the currently broken stable/8.7 CI, by:

- Backport of #1421.
- Alignment of spring boot version with [camunda/camunda stable/8.7](https://github.com/camunda/camunda/blob/stable/8.7/parent/pom.xml#L103). 
- Removal of explicit management of httpcore, to be inherited from the camunda/camunda deps instead.  (Otherwise test runtime issues occurred)
- Removal of explicit spring-core dependency, to use version managed by spring-boot bom. (Otherwise test runtime issues occurred)

