### PR TITLE
deps: use root pom version for module dependencies

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.6.9</version>
+    <version>8.6.10-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/assertions/pom.xml
+++ b/assertions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.6.9</version>
+    <version>8.6.10-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/engine-agent/pom.xml
+++ b/engine-agent/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.6.9</version>
+    <version>8.6.10-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/engine-protocol/pom.xml
+++ b/engine-protocol/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.6.9</version>
+    <version>8.6.10-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.6.9</version>
+    <version>8.6.10-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.6.7-rc5-SNAPSHOT</version>
+    <version>8.6.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>zeebe-process-test-examples</artifactId>

--- a/extension-testcontainer/pom.xml
+++ b/extension-testcontainer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.6.9</version>
+    <version>8.6.10-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.6.9</version>
+    <version>8.6.10-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/filters/pom.xml
+++ b/filters/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.6.9</version>
+    <version>8.6.10-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>io.camunda</groupId>
   <artifactId>zeebe-process-test-root</artifactId>
-  <version>8.6.7-rc5-SNAPSHOT</version>
+  <version>8.6.10-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Zeebe Process Test Root</name>
@@ -130,49 +130,49 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-api</artifactId>
-        <version>8.6.9</version>
+        <version>8.6.10-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-assertions</artifactId>
-        <version>8.6.9</version>
+        <version>8.6.10-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-engine</artifactId>
-        <version>8.6.9</version>
+        <version>8.6.10-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-extension</artifactId>
-        <version>8.6.9</version>
+        <version>8.6.10-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-extension-testcontainer</artifactId>
-        <version>8.6.9</version>
+        <version>8.6.10-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-filters</artifactId>
-        <version>8.6.9</version>
+        <version>8.6.10-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-engine-protocol</artifactId>
-        <version>8.6.9</version>
+        <version>8.6.10-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>spring-boot-starter-camunda-test-common</artifactId>
-        <version>8.6.9</version>
+        <version>8.6.10-SNAPSHOT</version>
       </dependency>
 
       <dependency>

--- a/qa/abstracts/pom.xml
+++ b/qa/abstracts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-qa</artifactId>
-    <version>8.6.9</version>
+    <version>8.6.10-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/qa/embedded/pom.xml
+++ b/qa/embedded/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-qa</artifactId>
-    <version>8.6.9</version>
+    <version>8.6.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>zeebe-process-test-qa-embedded</artifactId>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.6.9</version>
+    <version>8.6.10-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -27,7 +27,7 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-qa-abstracts</artifactId>
-        <version>8.6.9</version>
+        <version>8.6.10-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/qa/testcontainers/pom.xml
+++ b/qa/testcontainers/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-qa</artifactId>
-    <version>8.6.9</version>
+    <version>8.6.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>zeebe-process-test-qa-testcontainers</artifactId>

--- a/spring-test/common/pom.xml
+++ b/spring-test/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>spring-boot-starter-camunda-test-pom</artifactId>
-    <version>8.6.9</version>
+    <version>8.6.10-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/spring-test/embedded/pom.xml
+++ b/spring-test/embedded/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>spring-boot-starter-camunda-test-pom</artifactId>
-    <version>8.6.9</version>
+    <version>8.6.10-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/spring-test/pom.xml
+++ b/spring-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-process-test-root</artifactId>
-    <version>8.6.9</version>
+    <version>8.6.10-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/spring-test/testcontainer/pom.xml
+++ b/spring-test/testcontainer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>spring-boot-starter-camunda-test-pom</artifactId>
-    <version>8.6.9</version>
+    <version>8.6.10-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
## Description

Module versions got messed up by renovate.

See e.g. https://github.com/camunda/zeebe-process-test/commit/805ddacc8b76a9ff199b810fa98b2b8e051d1b20 , we need to exclude the repo modules in renovate in a follow-up.
