### PR TITLE
[backport stable/8.6] deps: use bpmn model 7.19 on relevant jdk8 modules

### DIFF
--- a/assertions/pom.xml
+++ b/assertions/pom.xml
@@ -17,8 +17,26 @@
   <description>Assertions for verifying the state of a process.</description>
 
   <properties>
+    <!-- needed as newer model releases don't support jdk 8 -->
+    <dependency.camundamodel.version>7.19.0</dependency.camundamodel.version>
     <version.java>8</version.java>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.camunda.bpm.model</groupId>
+        <artifactId>camunda-dmn-model</artifactId>
+        <version>${dependency.camundamodel.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.camunda.bpm.model</groupId>
+        <artifactId>camunda-xml-model</artifactId>
+        <version>${dependency.camundamodel.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>

--- a/qa/testcontainers/pom.xml
+++ b/qa/testcontainers/pom.xml
@@ -12,8 +12,26 @@
   <name>Zeebe Process Test QA Testcontainers</name>
 
   <properties>
+    <!-- needed as newer model releases don't support jdk 8 -->
+    <dependency.camundamodel.version>7.19.0</dependency.camundamodel.version>
     <version.java>8</version.java>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.camunda.bpm.model</groupId>
+        <artifactId>camunda-dmn-model</artifactId>
+        <version>${dependency.camundamodel.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.camunda.bpm.model</groupId>
+        <artifactId>camunda-xml-model</artifactId>
+        <version>${dependency.camundamodel.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
## Description

Backport of #1496

## Related issues

closes #https://github.com/camunda/zeebe-process-test/issues/1493