### PR TITLE
fix: set required meter registry

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
@@ -133,6 +133,7 @@ public class EngineFactory {
         .withLogStorage(logStorage)
         .withActorSchedulingService(scheduler)
         .withClock(clock)
+        .withMeterRegistry(new SimpleMeterRegistry())
         .build();
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <dependency.awaitility.version>4.2.2</dependency.awaitility.version>
     <dependency.bytebuddy.version>1.14.16</dependency.bytebuddy.version>
     <dependency.camundamodel.version>7.22.0</dependency.camundamodel.version>
+    <dependency.checkerframework.version>3.48.4</dependency.checkerframework.version>
     <dependency.classgraph.version>4.8.179</dependency.classgraph.version>
     <dependency.commons.version>3.14.0</dependency.commons.version>
     <dependency.errorprone.version>2.29.0</dependency.errorprone.version>
@@ -475,6 +476,12 @@
         <version>${dependency.spring-boot.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.checkerframework</groupId>
+        <artifactId>checker-qual</artifactId>
+        <version>${dependency.checkerframework.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/spring-test/common/pom.xml
+++ b/spring-test/common/pom.xml
@@ -11,10 +11,6 @@
   <artifactId>spring-boot-starter-camunda-test-common</artifactId>
   <name>Spring Boot Starter Camunda Test commons</name>
 
-  <properties>
-    <version.checker-qual>3.42.0</version.checker-qual>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -50,7 +46,6 @@
     <dependency>
       <groupId>org.checkerframework</groupId>
       <artifactId>checker-qual</artifactId>
-      <version>${version.checker-qual}</version>
     </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>


### PR DESCRIPTION
Meter registry is required, we can provide a new `SimpleMeterRegistry` that is appropriate for testing.