### PR TITLE
deps: bump jackson version to 2.18.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <dependency.findbugs.version>3.0.2</dependency.findbugs.version>
     <dependency.guava.version>32.1.3-jre</dependency.guava.version>
     <dependency.immutables.version>2.10.1</dependency.immutables.version>
-    <dependency.jackson.version>2.16.0</dependency.jackson.version>
+    <dependency.jackson.version>2.18.3</dependency.jackson.version>
     <dependency.javax.version>1.3.2</dependency.javax.version>
     <dependency.jna.version>5.13.0</dependency.jna.version>
     <dependency.junit.version>5.10.1</dependency.junit.version>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Bump the Jackson version to 2.18.3. This version is also used in Zeebe `8.4` and `8.5` and is required as Zeebe uses
methods that were added with this version.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1542

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
