### PR TITLE
deps: bump dependencies for 8.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <dependency.findbugs.version>3.0.2</dependency.findbugs.version>
     <dependency.guava.version>33.1.0-jre</dependency.guava.version>
     <dependency.immutables.version>2.10.1</dependency.immutables.version>
-    <dependency.jackson.version>2.17.0</dependency.jackson.version>
+    <dependency.jackson.version>2.18.3</dependency.jackson.version>
     <dependency.javax.version>1.3.2</dependency.javax.version>
     <dependency.jna.version>5.14.0</dependency.jna.version>
     <dependency.junit.version>5.10.2</dependency.junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -457,7 +457,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5</artifactId>
-        <version>5.2.5</version>
+        <version>5.3.3</version>
       </dependency>
 
       <!-- to avoid dependency convergence issue, pin to same version as zeebe's -->


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
* Bump the Jackson version to 2.18.3. This version is also used in Zeebe and is required as Zeebe uses
methods that were added with this version.
* Align the httpcore5 version used in ZPT with the version used in Zeebe 8.5 (httpcore5:5.3.3).
* 
⚠️ Merging is blocked until it is determined if we need to downgrade to `httpcore5:5.3.2` and re-release a `8.5` patch.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1542
closes #1545

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
