### PR TITLE
Fix the build

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDb.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDb.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.process.test.engine.db;
 import io.camunda.zeebe.db.*;
 import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.protocol.EnumValue;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -57,6 +59,11 @@ final class InMemoryDb<ColumnFamilyType extends Enum<? extends EnumValue> & Enum
   @Override
   public TransactionContext createContext() {
     return new InMemoryDbTransactionContext(database);
+  }
+
+  @Override
+  public MeterRegistry getMeterRegistry() {
+    return new SimpleMeterRegistry();
   }
 
   @Override

--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -140,6 +140,9 @@ public class RecordStreamLogger {
     valueTypeLoggers.put(ValueType.REDISTRIBUTION, Object::toString);
     valueTypeLoggers.put(ValueType.IDENTITY_SETUP, Object::toString);
     valueTypeLoggers.put(ValueType.RESOURCE, Object::toString);
+    valueTypeLoggers.put(ValueType.BATCH_OPERATION_CREATION, Object::toString);
+    valueTypeLoggers.put(ValueType.BATCH_OPERATION_EXECUTION, Object::toString);
+    valueTypeLoggers.put(ValueType.BATCH_OPERATION_CHUNK, Object::toString);
   }
 
   public void log() {

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <dependency.netty.version>4.1.116.Final</dependency.netty.version>
     <dependency.osgi.version>6.0.0</dependency.osgi.version>
     <dependency.proto.version>2.50.0</dependency.proto.version>
-    <dependency.protobuf.version>4.29.3</dependency.protobuf.version>
+    <dependency.protobuf.version>4.30.1</dependency.protobuf.version>
     <dependency.revapi.version>0.28.1</dependency.revapi.version>
     <dependency.scala.version>2.13.16</dependency.scala.version>
     <dependency.slf4j.version>2.0.16</dependency.slf4j.version>
@@ -124,7 +124,7 @@
     <!-- Note: needs to be aligned with the version used by io.camunda:camunda-client-java -->
     <version.grpc>1.70.0</version.grpc>
     <version.java>21</version.java>
-    <version.protobuf>4.29.2</version.protobuf>
+    <version.protobuf>4.30.1</version.protobuf>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

The build was broken, and some tests were failing:
- New record values are implemented by record stream loggers
- protobuf version is updated to align with zeebe protocol
- `InMemoryDb` now implements the new `getMeterRegistry()` method of `ZeebeDb` using `SimpleMeterRegistry`

## Related issues

<!-- Which issues are closed by this PR or are related -->

NA
