### PR TITLE
ci: fix slack notification on failing snapshot test

### DIFF
--- a/.github/workflows/snapshot-test.yml
+++ b/.github/workflows/snapshot-test.yml
@@ -50,6 +50,8 @@ jobs:
         name: Send slack notification
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {
@@ -71,6 +73,3 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
This action was bumped to 2.0 without changing the usage in the workflow.
