### PR TITLE
Log all unknown records using toString

### DIFF
--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -59,6 +59,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -101,7 +102,6 @@ public class RecordStreamLogger {
 
     // These records don't have any interesting extra information for the user to log
     valueTypeLoggers.put(ValueType.DEPLOYMENT_DISTRIBUTION, Object::toString);
-    valueTypeLoggers.put(ValueType.SBE_UNKNOWN, Object::toString);
     valueTypeLoggers.put(ValueType.NULL_VAL, Object::toString);
 
     // DMN will not be part of the initial 1.4 release
@@ -169,7 +169,7 @@ public class RecordStreamLogger {
   }
 
   private String logRecordDetails(final Record<?> record) {
-    return valueTypeLoggers.getOrDefault(record.getValueType(), var -> "").apply(record);
+    return valueTypeLoggers.getOrDefault(record.getValueType(), Objects::toString).apply(record);
   }
 
   private String logJobRecordValue(final Record<?> record) {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Every time a record value is added, the RecordStreamLoggerTest fails because we need to implement a nice record logger for that record value.

However, every time we just implement it with toString, which internally uses toJson to fix the failing test.

Instead, of failing every time, we can just accept that new records are logged as json.
