### PR TITLE
Provide a no results search query proxy

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -87,6 +87,16 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-domain</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
@@ -163,7 +163,8 @@ public class EngineFactory {
                             new SubscriptionCommandSender(context.getPartitionId(), commandSender),
                             commandSender,
                             FeatureFlags.createDefault(),
-                            jobStreamer),
+                            jobStreamer,
+                            new NoResultsSearchClientsProxy()),
                     new EngineConfiguration(),
                     new SecurityConfiguration())))
         .actorSchedulingService(scheduler)

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/NoResultsSearchClientsProxy.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/NoResultsSearchClientsProxy.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+
+package io.camunda.zeebe.process.test.engine;
+
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.entities.AuthorizationEntity;
+import io.camunda.search.entities.BatchOperationEntity;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
+import io.camunda.search.entities.DecisionDefinitionEntity;
+import io.camunda.search.entities.DecisionInstanceEntity;
+import io.camunda.search.entities.DecisionRequirementsEntity;
+import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.search.entities.FormEntity;
+import io.camunda.search.entities.GroupEntity;
+import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.entities.MappingEntity;
+import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.entities.RoleEntity;
+import io.camunda.search.entities.TenantEntity;
+import io.camunda.search.entities.UserEntity;
+import io.camunda.search.entities.UserTaskEntity;
+import io.camunda.search.entities.VariableEntity;
+import io.camunda.search.query.AuthorizationQuery;
+import io.camunda.search.query.BatchOperationQuery;
+import io.camunda.search.query.DecisionDefinitionQuery;
+import io.camunda.search.query.DecisionInstanceQuery;
+import io.camunda.search.query.DecisionRequirementsQuery;
+import io.camunda.search.query.FlowNodeInstanceQuery;
+import io.camunda.search.query.FormQuery;
+import io.camunda.search.query.GroupQuery;
+import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.MappingQuery;
+import io.camunda.search.query.ProcessDefinitionQuery;
+import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.search.query.RoleQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.TenantQuery;
+import io.camunda.search.query.UsageMetricsQuery;
+import io.camunda.search.query.UserQuery;
+import io.camunda.search.query.UserTaskQuery;
+import io.camunda.search.query.VariableQuery;
+import io.camunda.security.auth.SecurityContext;
+import java.util.List;
+
+/** Simple search clients proxy that always returns empty results. */
+@SuppressWarnings("unchecked")
+class NoResultsSearchClientsProxy implements SearchClientsProxy {
+
+  public static final SearchQueryResult<?> EMPTY_SEARCH_QUERY_RESULT =
+      new SearchQueryResult<>(0, List.of(), new Object[] {}, new Object[] {});
+
+  @Override
+  public SearchClientsProxy withSecurityContext(final SecurityContext securityContext) {
+    return this;
+  }
+
+  @Override
+  public SearchQueryResult<AuthorizationEntity> searchAuthorizations(
+      final AuthorizationQuery filter) {
+    return (SearchQueryResult<AuthorizationEntity>) EMPTY_SEARCH_QUERY_RESULT;
+  }
+
+  @Override
+  public List<AuthorizationEntity> findAllAuthorizations(final AuthorizationQuery filter) {
+    return List.of();
+  }
+
+  @Override
+  public SearchQueryResult<BatchOperationEntity> searchBatchOperations(
+      final BatchOperationQuery query) {
+    return (SearchQueryResult<BatchOperationEntity>) EMPTY_SEARCH_QUERY_RESULT;
+  }
+
+  @Override
+  public List<BatchOperationItemEntity> getBatchOperationItems(final Long batchOperationKey) {
+    return List.of();
+  }
+
+  @Override
+  public SearchQueryResult<DecisionDefinitionEntity> searchDecisionDefinitions(
+      final DecisionDefinitionQuery filter) {
+    return (SearchQueryResult<DecisionDefinitionEntity>) EMPTY_SEARCH_QUERY_RESULT;
+  }
+
+  @Override
+  public SearchQueryResult<DecisionInstanceEntity> searchDecisionInstances(
+      final DecisionInstanceQuery filter) {
+    return (SearchQueryResult<DecisionInstanceEntity>) EMPTY_SEARCH_QUERY_RESULT;
+  }
+
+  @Override
+  public SearchQueryResult<DecisionRequirementsEntity> searchDecisionRequirements(
+      final DecisionRequirementsQuery filter) {
+    return (SearchQueryResult<DecisionRequirementsEntity>) EMPTY_SEARCH_QUERY_RESULT;
+  }
+
+  @Override
+  public SearchQueryResult<FlowNodeInstanceEntity> searchFlowNodeInstances(
+      final FlowNodeInstanceQuery filter) {
+    return (SearchQueryResult<FlowNodeInstanceEntity>) EMPTY_SEARCH_QUERY_RESULT;
+  }
+
+  @Override
+  public SearchQueryResult<FormEntity> searchForms(final FormQuery filter) {
+    return (SearchQueryResult<FormEntity>) EMPTY_SEARCH_QUERY_RESULT;
+  }
+
+  @Override
+  public SearchQueryResult<GroupEntity> searchGroups(final GroupQuery query) {
+    return (SearchQueryResult<GroupEntity>) EMPTY_SEARCH_QUERY_RESULT;
+  }
+
+  @Override
+  public List<GroupEntity> findAllGroups(final GroupQuery query) {
+    return List.of();
+  }
+
+  @Override
+  public SearchQueryResult<IncidentEntity> searchIncidents(final IncidentQuery filter) {
+    return (SearchQueryResult<IncidentEntity>) EMPTY_SEARCH_QUERY_RESULT;
+  }
+
+  @Override
+  public SearchQueryResult<MappingEntity> searchMappings(final MappingQuery filter) {
+    return (SearchQueryResult<MappingEntity>) EMPTY_SEARCH_QUERY_RESULT;
+  }
+
+  @Override
+  public List<MappingEntity> findAllMappings(final MappingQuery query) {
+    return List.of();
+  }
+
+  @Override
+  public SearchQueryResult<ProcessDefinitionEntity> searchProcessDefinitions(
+      final ProcessDefinitionQuery filter) {
+    return (SearchQueryResult<ProcessDefinitionEntity>) EMPTY_SEARCH_QUERY_RESULT;
+  }
+
+  @Override
+  public SearchQueryResult<ProcessInstanceEntity> searchProcessInstances(
+      final ProcessInstanceQuery query) {
+    return (SearchQueryResult<ProcessInstanceEntity>) EMPTY_SEARCH_QUERY_RESULT;
+  }
+
+  @Override
+  public SearchQueryResult<RoleEntity> searchRoles(final RoleQuery filter) {
+    return (SearchQueryResult<RoleEntity>) EMPTY_SEARCH_QUERY_RESULT;
+  }
+
+  @Override
+  public List<RoleEntity> findAllRoles(final RoleQuery filter) {
+    return List.of();
+  }
+
+  @Override
+  public SearchQueryResult<TenantEntity> searchTenants(final TenantQuery filter) {
+    return (SearchQueryResult<TenantEntity>) EMPTY_SEARCH_QUERY_RESULT;
+  }
+
+  @Override
+  public List<TenantEntity> findAllTenants(final TenantQuery query) {
+    return List.of();
+  }
+
+  @Override
+  public Long countAssignees(final UsageMetricsQuery query) {
+    return 0L;
+  }
+
+  @Override
+  public Long countProcessInstances(final UsageMetricsQuery query) {
+    return 0L;
+  }
+
+  @Override
+  public Long countDecisionInstances(final UsageMetricsQuery query) {
+    return 0L;
+  }
+
+  @Override
+  public SearchQueryResult<UserEntity> searchUsers(final UserQuery userQuery) {
+    return (SearchQueryResult<UserEntity>) EMPTY_SEARCH_QUERY_RESULT;
+  }
+
+  @Override
+  public SearchQueryResult<UserTaskEntity> searchUserTasks(final UserTaskQuery filter) {
+    return (SearchQueryResult<UserTaskEntity>) EMPTY_SEARCH_QUERY_RESULT;
+  }
+
+  @Override
+  public SearchQueryResult<VariableEntity> searchVariables(final VariableQuery filter) {
+    return (SearchQueryResult<VariableEntity>) EMPTY_SEARCH_QUERY_RESULT;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,18 @@
       </dependency>
 
       <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-search-client</artifactId>
+        <version>${dependency.zeebe.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-search-domain</artifactId>
+        <version>${dependency.zeebe.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${dependency.slf4j.version}</version>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

The EngineProcessors.createEngineProcessors method now requires a new SearchClientsProxy (https://github.com/camunda/camunda/pull/30146). While it's not actually used yet, it may be used in the future, although it won't serve any purpose in ZPT. Therefore, it's reasonable to implement it with a static implementation that always provides 0 results. This should at least allow compilation of ZPT again.

Please note that this implementation cannot easily be maintained. New additions to the SearchClientsProxy interface will demand new implementations in the NoResultsSearchClientsProxy. We should investigate whether we can find a different place for the proxy to be passed to the processors.

## Related issues

<!-- Which issues are closed by this PR or are related -->

https://github.com/camunda/zeebe-process-test/actions/runs/14074650499/job/39415365949

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
