### PR TITLE
ci: run spring testcontainers test in tc job

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Build
         id: build
         run: |
-          mvn clean -B -U -pl ":zeebe-process-test-qa-testcontainers" -P !localBuild -am "-Dsurefire.rerunFailingTestsCount=5" install -DskipChecks
+          mvn clean -B -U -pl ":zeebe-process-test-qa-testcontainers,:spring-boot-starter-camunda-test-testcontainer" -P !localBuild -am "-Dsurefire.rerunFailingTestsCount=5" install -DskipChecks
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/snapshot-test.yml
+++ b/.github/workflows/snapshot-test.yml
@@ -1,5 +1,6 @@
 name: Zeebe SNAPSHOT test
 on:
+  workflow_dispatch: { }
   workflow_call: { }
   schedule:
     - cron: "0 3 * * 1-5"
@@ -30,7 +31,7 @@ jobs:
             NEW_ZEEBE_VERSION=`echo $CURRENT_ZEEBE_VERSION | awk -F. '/[0-9]+\./{$2++;print}' OFS=.`-SNAPSHOT
           fi
           echo $NEW_ZEEBE_VERSION
-          mvn -B -U -pl "-:zeebe-process-test-qa-testcontainers" -P !localBuild "-Dsurefire.rerunFailingTestsCount=5" -Ddependency.zeebe.version=$NEW_ZEEBE_VERSION clean install
+          mvn -B -U -P !localBuild "-Dsurefire.rerunFailingTestsCount=5" -Ddependency.zeebe.version=$NEW_ZEEBE_VERSION clean install
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description

There were two things off.

1. the `Run tests on ubuntu-latest using testcontainers` job of the `Build and test` workflow was not running the `spring-boot-starter-camunda-test-testcontainer` module but only `zeebe-process-test-qa-testcontainers`, thus we missed to detect broken tests in PRs.

2. The nightly `Zeebe SNAPSHOT test` workflow was running the `spring-boot-starter-camunda-test-testcontainer` tests but not the `zeebe-process-test-qa-testcontainers` tests, with 9d55c2a758ac7134dbd1e931578330f92d103093 it now builds and tests all modules 