### PR TITLE
[backport stable/8.7] ci: run spring testcontainers test in tc job

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -113,18 +113,9 @@ jobs:
           IMAGE_NAME_KEY: container.image.name
           IMAGE_TAG_KEY: container.image.tag
 
-      - name: Downgrade Java environment
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 8
-          cache: maven
-
-      # Deleting .mvn/jvm.config is a workaround for JDK8, which does not support the --add-exports options
       - name: Build
         id: build
         run: |
-          rm .mvn/jvm.config
           mvn clean -B -U -pl ":zeebe-process-test-qa-testcontainers" -P !localBuild -am "-Dsurefire.rerunFailingTestsCount=5" install -DskipChecks
 
       - name: Archive Test Results

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Build
         id: build
         run: |
-          mvn clean -B -U -pl ":zeebe-process-test-qa-testcontainers" -P !localBuild -am "-Dsurefire.rerunFailingTestsCount=5" install -DskipChecks
+          mvn clean -B -U -pl ":zeebe-process-test-qa-testcontainers,:spring-boot-starter-camunda-test-testcontainer" -P !localBuild -am "-Dsurefire.rerunFailingTestsCount=5" install -DskipChecks
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/snapshot-test.yml
+++ b/.github/workflows/snapshot-test.yml
@@ -1,5 +1,6 @@
 name: Zeebe SNAPSHOT test
 on:
+  workflow_dispatch: { }
   workflow_call: { }
   schedule:
     - cron: "0 3 * * 1-5"
@@ -30,7 +31,7 @@ jobs:
             NEW_ZEEBE_VERSION=`echo $CURRENT_ZEEBE_VERSION | awk -F. '/[0-9]+\./{$2++;print}' OFS=.`-SNAPSHOT
           fi
           echo $NEW_ZEEBE_VERSION
-          mvn -B -U -pl "-:zeebe-process-test-qa-testcontainers" -P !localBuild "-Dsurefire.rerunFailingTestsCount=5" -Ddependency.zeebe.version=$NEW_ZEEBE_VERSION clean install
+          mvn -B -U -P !localBuild "-Dsurefire.rerunFailingTestsCount=5" -Ddependency.zeebe.version=$NEW_ZEEBE_VERSION clean install
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v4

--- a/spring-test/testcontainer/pom.xml
+++ b/spring-test/testcontainer/pom.xml
@@ -77,6 +77,12 @@
       <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/spring-test/testcontainer/pom.xml
+++ b/spring-test/testcontainer/pom.xml
@@ -33,6 +33,13 @@
       <groupId>io.camunda</groupId>
       <artifactId>spring-boot-starter-camunda-sdk</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <!-- we don't want actuator autoconfiguration for testing -->
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>


### PR DESCRIPTION
## Description

backport of https://github.com/camunda/zeebe-process-test/pull/1609

With additional changes needed to account for the state of stable/8.7

1.  Backport of https://github.com/camunda/zeebe-process-test/pull/1388 to remove jdk downgrade, that would cause this change to fail given that the sdk tc job requires jdk 17, done via 0e8632fa52fd5fb6d1ae6c1d400a268969ef594c
2. Adding slf4j-simple via b02acc93c8eaa55825fbfd8a2c234d7ab0e1d7ab to actually see logs from the spring tc test cases, this was done on main already with https://github.com/camunda/zeebe-process-test/commit/6dbc2a30f20dafc783343b71646a5ba921823fff
3. Fixing the spring tc tests by excluding the actuator-autoconfigure dependency via f26795e35385bdce5887a9cddbdaf78d7fe17eee, see this comment on why https://github.com/camunda/zeebe-process-test/pull/1617#issuecomment-2877467613

closes #1389

