### PR TITLE
ci: collect surefire reports from nested modules

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -73,7 +73,7 @@ jobs:
         if: always()
         with:
           name: Unit Test Results ${{ matrix.os }}
-          path: "*/target/surefire-reports/"
+          path: "**/target/surefire-reports/"
           retention-days: 7
 
   build-and-test-testcontainers:
@@ -123,7 +123,7 @@ jobs:
         if: always()
         with:
           name: Unit Test Results Testcontainers
-          path: "*/target/surefire-reports/"
+          path: "**/target/surefire-reports/"
           retention-days: 7
 
   test-summary:

--- a/.github/workflows/snapshot-test.yml
+++ b/.github/workflows/snapshot-test.yml
@@ -38,7 +38,7 @@ jobs:
         if: always()
         with:
           name: Unit Test Results Against Zeebe Snapshot
-          path: "*/target/surefire-reports/"
+          path: "**/target/surefire-reports/"
           retention-days: 7
 
   notify-if-failed:


### PR DESCRIPTION
## Description

Previous setup was just collecting the report from the top level modules, due to the non-recursive glob pattern used.

relates https://github.com/camunda/zeebe-process-test/issues/1619 - for being able to check the logs of the flaky tests

