### PR TITLE
feat: fix compilation error introduce by adding ScopedColumnFamily bound

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDb.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDb.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.process.test.engine.db;
 import io.camunda.zeebe.db.*;
 import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.protocol.EnumValue;
+import io.camunda.zeebe.protocol.ScopedColumnFamily;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
@@ -31,7 +32,8 @@ import java.util.TreeMap;
  *
  * @param <ColumnFamilyType>
  */
-final class InMemoryDb<ColumnFamilyType extends Enum<? extends EnumValue> & EnumValue>
+final class InMemoryDb<
+        ColumnFamilyType extends Enum<? extends EnumValue> & EnumValue & ScopedColumnFamily>
     implements ZeebeDb<ColumnFamilyType> {
 
   private final TreeMap<Bytes, Bytes> database = new TreeMap<>();
@@ -62,13 +64,13 @@ final class InMemoryDb<ColumnFamilyType extends Enum<? extends EnumValue> & Enum
   }
 
   @Override
-  public MeterRegistry getMeterRegistry() {
-    return new SimpleMeterRegistry();
+  public boolean isEmpty(final ColumnFamilyType column, final TransactionContext context) {
+    return createColumnFamily(column, context, DbNullKey.INSTANCE, DbNil.INSTANCE).isEmpty();
   }
 
   @Override
-  public boolean isEmpty(final ColumnFamilyType column, final TransactionContext context) {
-    return createColumnFamily(column, context, DbNullKey.INSTANCE, DbNil.INSTANCE).isEmpty();
+  public MeterRegistry getMeterRegistry() {
+    return new SimpleMeterRegistry();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbColumnFamily.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbColumnFamily.java
@@ -13,7 +13,9 @@ import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.db.KeyValuePairVisitor;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDbInconsistentException;
+import io.camunda.zeebe.protocol.ColumnFamilyScope;
 import io.camunda.zeebe.protocol.EnumValue;
+import io.camunda.zeebe.protocol.ScopedColumnFamily;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Iterator;
 import java.util.Map;
@@ -26,7 +28,7 @@ import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
 
 final class InMemoryDbColumnFamily<
-        ColumnFamilyNames extends Enum<? extends EnumValue> & EnumValue,
+        ColumnFamilyNames extends Enum<? extends EnumValue> & EnumValue & ScopedColumnFamily,
         KeyType extends DbKey,
         ValueType extends DbValue>
     implements ColumnFamily<KeyType, ValueType> {
@@ -205,6 +207,11 @@ final class InMemoryDbColumnFamily<
   @Override
   public long countEqualPrefix(final DbKey prefix) {
     return countEachInPrefix(prefix);
+  }
+
+  @Override
+  public ColumnFamilyScope partitionScope() {
+    return columnFamily.partitionScope();
   }
 
   private DirectBuffer getValue(final InMemoryDbState state, final DbKey key) {

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbFactory.java
@@ -10,9 +10,11 @@ package io.camunda.zeebe.process.test.engine.db;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.protocol.EnumValue;
+import io.camunda.zeebe.protocol.ScopedColumnFamily;
 import java.io.File;
 
-public class InMemoryDbFactory<ColumnFamilyType extends Enum<? extends EnumValue> & EnumValue>
+public class InMemoryDbFactory<
+        ColumnFamilyType extends Enum<? extends EnumValue> & EnumValue & ScopedColumnFamily>
     implements ZeebeDbFactory<ColumnFamilyType> {
 
   public ZeebeDb<ColumnFamilyType> createDb() {

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/InMemoryZeebeDbTransactionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/InMemoryZeebeDbTransactionTest.java
@@ -15,7 +15,9 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbTransaction;
 import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.protocol.ColumnFamilyScope;
 import io.camunda.zeebe.protocol.EnumValue;
+import io.camunda.zeebe.protocol.ScopedColumnFamily;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -556,7 +558,7 @@ public final class InMemoryZeebeDbTransactionTest {
         });
   }
 
-  private enum ColumnFamilies implements EnumValue {
+  private enum ColumnFamilies implements EnumValue, ScopedColumnFamily {
     DEFAULT(0), // rocksDB needs a default column family
     ONE(1),
     TWO(2),
@@ -571,6 +573,11 @@ public final class InMemoryZeebeDbTransactionTest {
     @Override
     public int getValue() {
       return value;
+    }
+
+    @Override
+    public ColumnFamilyScope partitionScope() {
+      return ColumnFamilyScope.PARTITION_LOCAL;
     }
   }
 }


### PR DESCRIPTION
## Description
Fixed compilation error that was caused by `ScopedColumnFamily` interface that was added to zeebe's `ColumnFamily`, but was not implemented here.
