### PR TITLE
fix: fix method signature in noop search client to match upstream ver…

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/NoResultsSearchClientsProxy.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/NoResultsSearchClientsProxy.java
@@ -81,7 +81,7 @@ class NoResultsSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
-  public List<BatchOperationItemEntity> getBatchOperationItems(final Long batchOperationKey) {
+  public List<BatchOperationItemEntity> getBatchOperationItems(final String batchOperationKey) {
     return List.of();
   }
 


### PR DESCRIPTION
## Description

This fixes a compile error coming from the upstream Camunda SNAPSHOT version. Where the `long batchOperationKey` was renamed to the `String batchOperationId` in the `BatchOperationSearchClient` interface

## Related issues

https://github.com/camunda/camunda/issues/31589
