### PR TITLE
ci: exclude io.camunda.** from renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -86,6 +86,16 @@
       ]
     },
     {
+      "description": "Exclude io.camunda updates, we manage deps to camunda components manually.",
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "io.camunda{/,}**"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Automerge all updates with green CI.",
       "automerge": true,
       "addLabels": [


### PR DESCRIPTION
## Description

It messed up inter-module dependencies (see #1622) and we generally maintain dependencies to camunda/camunda manually as part of the release.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates #1622 
