### PR TITLE
build: align versions to current 8.7 dev version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,43 +130,43 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-api</artifactId>
-        <version>8.7.1</version>
+        <version>8.7.3-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-assertions</artifactId>
-        <version>8.7.1</version>
+        <version>8.7.3-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-engine</artifactId>
-        <version>8.7.1</version>
+        <version>8.7.3-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-extension</artifactId>
-        <version>8.7.1</version>
+        <version>8.7.3-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-extension-testcontainer</artifactId>
-        <version>8.7.1</version>
+        <version>8.7.3-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-filters</artifactId>
-        <version>8.7.1</version>
+        <version>8.7.3-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-engine-protocol</artifactId>
-        <version>8.7.1</version>
+        <version>8.7.3-SNAPSHOT</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

Inter-module versions references were pointing to a previous release but should use the current 8.7.x-SNAPSHOT.

## Related issues



closes #1622