### PR TITLE
Manage checker-qual version in parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <dependency.awaitility.version>4.3.0</dependency.awaitility.version>
     <dependency.bytebuddy.version>1.17.5</dependency.bytebuddy.version>
     <dependency.camundamodel.version>7.22.0</dependency.camundamodel.version>
+    <dependency.checker-qual.version>3.48.4</dependency.checker-qual.version>
     <dependency.classgraph.version>4.8.179</dependency.classgraph.version>
     <dependency.commons.version>3.17.0</dependency.commons.version>
     <dependency.errorprone.version>2.38.0</dependency.errorprone.version>
@@ -510,7 +511,7 @@
       <dependency>
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
-        <version>3.48.4</version>
+        <version>${dependency.checker-qual.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <dependency.awaitility.version>4.3.0</dependency.awaitility.version>
     <dependency.bytebuddy.version>1.17.5</dependency.bytebuddy.version>
     <dependency.camundamodel.version>7.22.0</dependency.camundamodel.version>
-    <dependency.checker-qual.version>3.48.4</dependency.checker-qual.version>
+    <dependency.checker-qual.version>3.49.3</dependency.checker-qual.version>
     <dependency.classgraph.version>4.8.179</dependency.classgraph.version>
     <dependency.commons.version>3.17.0</dependency.commons.version>
     <dependency.errorprone.version>2.38.0</dependency.errorprone.version>

--- a/spring-test/common/pom.xml
+++ b/spring-test/common/pom.xml
@@ -11,10 +11,6 @@
   <artifactId>spring-boot-starter-camunda-test-common</artifactId>
   <name>Spring Boot Starter Camunda Test commons</name>
 
-  <properties>
-    <version.checker-qual>3.48.4</version.checker-qual>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -54,7 +50,7 @@
     <dependency>
       <groupId>org.checkerframework</groupId>
       <artifactId>checker-qual</artifactId>
-      <version>${version.checker-qual}</version>
+      <version>${dependency.checker-qual.version}</version>
     </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>


### PR DESCRIPTION
## Description

Previously the version was managed in the spring module branch but convergence with the transitive dep of guava justifies moving version management to the project parent.

Also bumps version to latest superseding pending updates:
https://github.com/camunda/zeebe-process-test/pull/1449
https://github.com/camunda/zeebe-process-test/pull/1448