### PR TITLE
Removal of dependency management for spring-core and httpcore5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,6 @@
     <dependency.feel.version>1.19.3</dependency.feel.version>
     <dependency.findbugs.version>3.0.2</dependency.findbugs.version>
     <dependency.guava.version>33.4.8-jre</dependency.guava.version>
-    <dependency.httpcore5.version>5.3.4</dependency.httpcore5.version>
     <dependency.immutables.version>2.10.1</dependency.immutables.version>
     <dependency.jackson.version>2.18.2</dependency.jackson.version>
     <dependency.javax.version>1.3.2</dependency.javax.version>
@@ -446,11 +445,6 @@
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
         <version>${dependency.bytebuddy.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents.core5</groupId>
-        <artifactId>httpcore5</artifactId>
-        <version>${dependency.httpcore5.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jetbrains</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,6 @@
     <dependency.slf4j.version>2.0.17</dependency.slf4j.version>
     <dependency.snakeyaml.version>2.4</dependency.snakeyaml.version>
     <dependency.spring-boot.version>3.4.5</dependency.spring-boot.version>
-    <dependency.spring.version>6.2.6</dependency.spring.version>
     <dependency.testcontainers.version>1.21.0</dependency.testcontainers.version>
     <dependency.zeebe.version>8.8.0-SNAPSHOT</dependency.zeebe.version>
 
@@ -486,18 +485,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${dependency.commons.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-context</artifactId>
-        <version>${dependency.spring.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-core</artifactId>
-        <version>${dependency.spring.version}</version>
       </dependency>
 
       <!-- fix dependency convergence between guava and spring-boot-starter-camunda-test-common -->


### PR DESCRIPTION
## Description

As done on 8.7 previously via https://github.com/camunda/zeebe-process-test/pull/1499 (missed to be forward-ported 🤷 ) we don't need to manage spring-core and httpcore5 but rely on the version managed via the [`spring-boot-depencies` bom](https://github.com/camunda/zeebe-process-test/compare/meg-dep-simplification?expand=1#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R497) since https://github.com/camunda/zeebe-process-test/pull/1421/commits/7a9a86d05f8c286be73019d6b881c82cf3d2bcbe.