### PR TITLE
build: remove version management for msgpack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,6 @@
     <dependency.junit4.version>4.13.2</dependency.junit4.version>
     <dependency.micrometer.version>1.13.3</dependency.micrometer.version>
     <dependency.mockito.version>4.11.0</dependency.mockito.version>
-    <dependency.msgpack.version>0.9.8</dependency.msgpack.version>
     <dependency.netty.version>4.1.119.Final</dependency.netty.version>
     <dependency.osgi.version>6.0.0</dependency.osgi.version>
     <dependency.proto.version>2.44.0</dependency.proto.version>
@@ -494,16 +493,6 @@
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
         <version>${dependency.checkerframework.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.msgpack</groupId>
-        <artifactId>jackson-dataformat-msgpack</artifactId>
-        <version>${dependency.msgpack.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.msgpack</groupId>
-        <artifactId>msgpack-core</artifactId>
-        <version>${dependency.msgpack.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Description

It's not used directly and the only transitive path is via `zeebe-protocol-impl`, see
```
[INFO] --- dependency:3.6.1:tree (default-cli) @ zeebe-process-test-engine ---
[INFO] io.camunda:zeebe-process-test-engine:jar:8.6.16-SNAPSHOT
[INFO] \- io.camunda:zeebe-protocol-impl:jar:8.6.15:compile
[INFO]    \- org.msgpack:jackson-dataformat-msgpack:jar:0.9.9:compile
[INFO]       \- org.msgpack:msgpack-core:jar:0.9.9:compile
[INFO]
...
[INFO] --- dependency:3.6.1:tree (default-cli) @ zeebe-process-test-engine-agent ---
[INFO] io.camunda:zeebe-process-test-engine-agent:jar:8.6.16-SNAPSHOT
[INFO] \- io.camunda:zeebe-process-test-engine:jar:8.6.16-SNAPSHOT:compile
[INFO]    \- io.camunda:zeebe-protocol-impl:jar:8.6.15:compile
[INFO]       \- org.msgpack:jackson-dataformat-msgpack:jar:0.9.9:compile
[INFO]          \- org.msgpack:msgpack-core:jar:0.9.9:compile
...
[INFO] --- dependency:3.6.1:tree (default-cli) @ zeebe-process-test-extension ---
[INFO] io.camunda:zeebe-process-test-extension:jar:8.6.16-SNAPSHOT
[INFO] \- io.camunda:zeebe-process-test-engine:jar:8.6.16-SNAPSHOT:compile
[INFO]    \- io.camunda:zeebe-protocol-impl:jar:8.6.15:compile
[INFO]       \- org.msgpack:jackson-dataformat-msgpack:jar:0.9.9:compile
[INFO]          \- org.msgpack:msgpack-core:jar:0.9.9:compile
...
[INFO] --- dependency:3.6.1:tree (default-cli) @ zeebe-process-test-qa-embedded ---
[INFO] io.camunda:zeebe-process-test-qa-embedded:jar:8.6.16-SNAPSHOT
[INFO] \- io.camunda:zeebe-process-test-extension:jar:8.6.16-SNAPSHOT:test
[INFO]    \- io.camunda:zeebe-process-test-engine:jar:8.6.16-SNAPSHOT:test
[INFO]       \- io.camunda:zeebe-protocol-impl:jar:8.6.15:test
[INFO]          \- org.msgpack:jackson-dataformat-msgpack:jar:0.9.9:test
[INFO]             \- org.msgpack:msgpack-core:jar:0.9.9:test
...
[INFO] --- dependency:3.6.1:tree (default-cli) @ zeebe-process-test-examples ---
[INFO] io.camunda:zeebe-process-test-examples:jar:8.6.16-SNAPSHOT
[INFO] \- io.camunda:zeebe-process-test-extension:jar:8.6.16-SNAPSHOT:test
[INFO]    \- io.camunda:zeebe-process-test-engine:jar:8.6.16-SNAPSHOT:test
[INFO]       \- io.camunda:zeebe-protocol-impl:jar:8.6.15:test
[INFO]          \- org.msgpack:jackson-dataformat-msgpack:jar:0.9.9:test
[INFO]             \- org.msgpack:msgpack-core:jar:0.9.9:test
...
[INFO] --- dependency:3.6.1:tree (default-cli) @ spring-boot-starter-camunda-test ---
[INFO] io.camunda:spring-boot-starter-camunda-test:jar:8.6.16-SNAPSHOT
[INFO] \- io.camunda:zeebe-process-test-engine:jar:8.6.16-SNAPSHOT:compile
[INFO]    \- io.camunda:zeebe-protocol-impl:jar:8.6.15:compile
[INFO]       \- org.msgpack:jackson-dataformat-msgpack:jar:0.9.9:compile
[INFO]          \- org.msgpack:msgpack-core:jar:0.9.9:compile
```