### PR TITLE
[backport stable/8.6] alignment of spring dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -470,13 +470,6 @@
         <version>${dependency.commons.version}</version>
       </dependency>
 
-      <!-- pin version to avoid dependency convergence issues -->
-      <dependency>
-        <groupId>org.apache.httpcomponents.core5</groupId>
-        <artifactId>httpcore5</artifactId>
-        <version>5.3.4</version>
-      </dependency>
-
       <dependency>
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency.scala.version>2.13.16</dependency.scala.version>
     <dependency.slf4j.version>2.0.17</dependency.slf4j.version>
     <dependency.snakeyaml.version>2.2</dependency.snakeyaml.version>
-    <dependency.spring-boot.version>3.3.7</dependency.spring-boot.version>
+    <dependency.spring-boot.version>3.4.5</dependency.spring-boot.version>
     <dependency.testcontainers.version>1.19.8</dependency.testcontainers.version>
     <dependency.zeebe.version>8.6.15</dependency.zeebe.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
     <dependency.scala.version>2.13.16</dependency.scala.version>
     <dependency.slf4j.version>2.0.17</dependency.slf4j.version>
     <dependency.snakeyaml.version>2.2</dependency.snakeyaml.version>
+    <dependency.spring-boot.version>3.3.7</dependency.spring-boot.version>
     <dependency.spring.version>6.1.14</dependency.spring.version>
     <dependency.testcontainers.version>1.19.8</dependency.testcontainers.version>
     <dependency.zeebe.version>8.6.15</dependency.zeebe.version>
@@ -493,6 +494,14 @@
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
         <version>${dependency.checkerframework.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${dependency.spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,6 @@
     <dependency.slf4j.version>2.0.17</dependency.slf4j.version>
     <dependency.snakeyaml.version>2.2</dependency.snakeyaml.version>
     <dependency.spring-boot.version>3.3.7</dependency.spring-boot.version>
-    <dependency.spring.version>6.1.14</dependency.spring.version>
     <dependency.testcontainers.version>1.19.8</dependency.testcontainers.version>
     <dependency.zeebe.version>8.6.15</dependency.zeebe.version>
 
@@ -469,18 +468,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${dependency.commons.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-context</artifactId>
-        <version>${dependency.spring.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-core</artifactId>
-        <version>${dependency.spring.version}</version>
       </dependency>
 
       <!-- pin version to avoid dependency convergence issues -->

--- a/spring-test/pom.xml
+++ b/spring-test/pom.xml
@@ -22,21 +22,7 @@
 
   <properties>
     <plugin.version.license>4.6</plugin.version.license>
-    <version.spring-boot>3.3.7</version.spring-boot>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <build>
     <plugins>


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/zeebe-process-test/pull/1499 to align dependency management from 8.6+, in relation to the new spring based modules.