### PR TITLE
build: set java version to 17 for spring modules

### DIFF
--- a/spring-test/pom.xml
+++ b/spring-test/pom.xml
@@ -22,6 +22,7 @@
 
   <properties>
     <plugin.version.license>5.0.0</plugin.version.license>
+    <version.java>17</version.java>
   </properties>
 
   <build>


### PR DESCRIPTION
## Description

Minimum version supported by the SDK is 17 according to docs. https://docs.camunda.io/docs/next/apis-tools/spring-zeebe-sdk/getting-started/#version-compatibility

We thus need to build the spring test modules for 17.