### PR TITLE
ci: use backport-action PAT on git checkout

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,6 +22,9 @@ jobs:
       )
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Token for git actions, e.g. git push, needed to be able to e.g. update workflow files
+          token: ${{ secrets.BACKPORT_ACTION_PAT }}
       - name: Create backport PRs
         uses: korthout/backport-action@v3
         with:

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/NoResultsSearchClientsProxy.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/NoResultsSearchClientsProxy.java
@@ -30,6 +30,7 @@ import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.AuthorizationQuery;
+import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
@@ -83,6 +84,12 @@ class NoResultsSearchClientsProxy implements SearchClientsProxy {
   @Override
   public List<BatchOperationItemEntity> getBatchOperationItems(final String batchOperationKey) {
     return List.of();
+  }
+
+  @Override
+  public SearchQueryResult<BatchOperationItemEntity> searchBatchOperationItems(
+      final BatchOperationItemQuery query) {
+    return (SearchQueryResult<BatchOperationItemEntity>) EMPTY_SEARCH_QUERY_RESULT;
   }
 
   @Override


### PR DESCRIPTION
## Description

This is needed so the action can push changes to workflows.

Otherwise backporting workflow changes fail with a permission error like:
```
 ! [remote rejected] backport-1617-to-stable/8.6 -> backport-1617-to-stable/8.6 (refusing to allow a GitHub App to create or update workflow `.github/workflows/build-test.yml` without `workflows` permission)
 ```
see e.g. https://github.com/camunda/zeebe-process-test/actions/runs/15013428320/job/42186200335

Which happened on https://github.com/camunda/zeebe-process-test/pull/1617

Similar change was done on camunda/camunda with https://github.com/camunda/camunda/pull/10785