### PR TITLE
[backport stable/8.6] build: set java version to 17 for spring modules

### DIFF
--- a/spring-test/pom.xml
+++ b/spring-test/pom.xml
@@ -22,6 +22,7 @@
 
   <properties>
     <plugin.version.license>4.6</plugin.version.license>
+    <version.java>17</version.java>
   </properties>
 
   <build>


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/zeebe-process-test/pull/1667