### PR TITLE
[backport stable/8.6] fix: adapt to removal of default mapper on camunda/camunda

### DIFF
--- a/spring-test/common/src/main/java/io/camunda/zeebe/spring/test/configuration/ZeebeTestDefaultConfiguration.java
+++ b/spring-test/common/src/main/java/io/camunda/zeebe/spring/test/configuration/ZeebeTestDefaultConfiguration.java
@@ -15,7 +15,8 @@
  */
 package io.camunda.zeebe.spring.test.configuration;
 
-import static io.camunda.zeebe.spring.client.configuration.CamundaAutoConfiguration.DEFAULT_OBJECT_MAPPER;
+import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.client.api.JsonMapper;
@@ -35,6 +36,8 @@ public class ZeebeTestDefaultConfiguration {
   @Bean
   @ConditionalOnMissingBean
   public ObjectMapper objectMapper() {
-    return DEFAULT_OBJECT_MAPPER;
+    return new ObjectMapper()
+        .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .configure(ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true);
   }
 }


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/zeebe-process-test/pull/1676