### PR TITLE
ci: new GHA workflow to automate manual release tasks

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           shopt -s nocasematch # set matching to case insensitive
           PRE_RELEASE=false
-          if [[ "${RELEASE_VERSION}" =~ ^.*-(alpha|rc|SNAPSHOT)[0-9]+[\.]*[0-9]*$ ]]; then
+          if [[ "${RELEASE_VERSION}" =~ ^.*-(alpha|rc|SNAPSHOT).*$ ]]; then
             PRE_RELEASE=true
           fi
           shopt -u nocasematch # reset it

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,188 @@
+---
+name: Create Release
+
+# Used by https://github.com/camunda/zeebe-engineering-processes/blob/main/src/main/resources/release/zeebe-process-test-release.bpmn
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'releaseVersion: e.g. MAJOR.MINOR.PATCH[-ALPHAn]'
+        type: string
+        required: true
+      minorVersion:
+        description: 'minorVersion: just the MAJOR.MINOR part of the releaseVersion'
+        type: string
+        required: true
+      releaseType:
+        description: 'releaseType: e.g. minor, alpha or patch'
+        type: string
+        required: true
+      nextDevelopmentVersion:
+        description: 'nextDevelopmentVersion: e.g. 8.X.X-SNAPSHOT'
+        type: string
+        required: true
+      isLatest:
+        description: 'isLatest: updates the `latest` docker tag'
+        type: boolean
+        required: false
+        default: false
+      releaseBranch:
+        description: 'releaseBranch: defaults to `release-$releaseVersion` if not set'
+        type: string
+        required: false
+        default: ''
+      dryRun:
+        description: 'dryRun: Whether to perform a dry release where no changes/artifacts are pushed'
+        type: boolean
+        required: true
+        default: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      RELEASE_BRANCH: ${{ inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
+      RELEASE_VERSION: ${{ inputs.releaseVersion }}
+      MINOR_VERSION: ${{ inputs.minorVersion }}
+    steps:
+      - name: Output inputs
+        run: echo "${{ toJSON(github.event.inputs) }}"
+
+      # This step generates a GitHub App token to be used in Git operations as a workaround  for
+      # the known GitHub issue described in https://github.com/camunda/camunda/issues/28522
+      - name: Generate GitHub token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        with:
+          github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
+          github-app-id-vault-path: secret/data/products/camunda/ci/camunda
+          github-app-private-key-vault-key: MONOREPO_RELEASE_APP_PRIVATE_KEY
+          github-app-private-key-vault-path: secret/data/products/camunda/ci/camunda
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID}}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+          # Overriding the default GITHUB_TOKEN with a GitHub App token in order to workaround
+          # the known GitHub issue described in https://github.com/camunda/camunda/issues/28522
+          # NOTES:
+          # - This token will be used for all git operations in this job
+          # - This token expires after 1 hour (https://github.com/actions/create-github-app-token?tab=readme-ov-file#create-github-app-token)
+          token: ${{ steps.github-token.outputs.token }}
+
+      - name: Setup Git user
+        run: |
+          git config --global user.email "github-actions[release]"
+          git config --global user.name "github-actions[release]@users.noreply.github.com"
+
+      - name: Set up Java environment
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
+      - name: Update Zeebe version
+        run: |
+          mvn -B versions:set-property -DgenerateBackupPoms=false -Dproperty=dependency.zeebe.version -DnewVersion="${RELEASE_VERSION}"
+          git commit -am "ci: update Zeebe version to ${RELEASE_VERSION}"
+
+      - name: Push changes to release branch
+        if: ${{ inputs.dryRun == false }}
+        run: |
+          git push origin "${RELEASE_BRANCH}"
+
+      - name: Create Git tag
+        run: |
+          git tag -a -m"${RELEASE_VERSION}" "${RELEASE_VERSION}"
+
+      - name: Push Git tag
+        if: ${{ inputs.dryRun == false }}
+        run: |
+          git push origin "${RELEASE_VERSION}"
+
+      - name: Create new stable branch for minor
+        if: ${{ inputs.releaseType == 'minor' }}
+        run: |
+          git checkout --branch "stable/${MINOR_VERSION}"
+          git push origin "stable/${MINOR_VERSION}"
+
+      # Same logic as in camunda/camunda
+      - name: Determine if pre-release
+        id: pre-release
+        run: |
+          shopt -s nocasematch # set matching to case insensitive
+          PRE_RELEASE=false
+          if [[ "${RELEASE_VERSION}" =~ ^.*-(alpha|rc|SNAPSHOT)[0-9]+[\.]*[0-9]*$ ]]; then
+            PRE_RELEASE=true
+          fi
+          shopt -u nocasematch # reset it
+          echo "result=${PRE_RELEASE}" >> $GITHUB_OUTPUT
+
+      # This step creates a GitHub release which indirectly triggers deploy-artifact.yml
+      - name: Create Github release
+        uses: ncipollo/release-action@v1
+        if: ${{ inputs.dryRun == false }}
+        with:
+          name: ${{ inputs.releaseVersion }}
+          tag: ${{ inputs.releaseVersion }}
+          generateReleaseNotes: true
+          prerelease: ${{ steps.pre-release.outputs.result }}
+          makeLatest: ${{ inputs.isLatest }}
+          token: ${{ steps.github-token.outputs.token }}
+
+  notify-if-failed:
+    name: Send Slack notification on failure
+    runs-on: ubuntu-latest
+    needs: [create-release]
+    # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
+    # else => send slack notification as an actual release failed
+    if: ${{ failure() && inputs.dryRun == false }}
+    timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
+    steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@7709c609789c5e27b757a85817483caadbb5939a # v3.3.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+
+      - name: Send failure Slack notification
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: *Creating ZPT release ${{ inputs.releaseVersion }}* failed!\n"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Please check this <https://github.com/camunda/zeebe-process-test/actions/runs/${{ github.run_id }}|GHA workflow run>."
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -1,15 +1,17 @@
 # If this workflow is triggered by a push to main, it deploys a SNAPSHOT
-# If this workflow is triggered manually, it deploys a SNAPSHOT
 # If this workflow is triggered by publishing a Release, it
 #        deploys a RELEASE with the selected version
 #        updates the project version by incrementing the patch version
 #        commits the version update change to the repository's default branch (main).
+---
 name: Deploy artifacts
+
 on:
   push:
     branches: [main]
   release:
     types: [published]
+
 jobs:
   test:
     uses: ./.github/workflows/build-test.yml
@@ -56,7 +58,7 @@ jobs:
           mvn clean package -DskipTests -P !localBuild -pl :zeebe-process-test-engine-agent -am
 
         # We build a docker image with a specific tag. There are 2 possible scenarios here.
-        # 1. The workflow is triggered manually or by a change on the main branch. The tag should be equal to the project.version.
+        # 1. The workflow is triggered by a change on the main branch. The tag should be equal to the project.version.
         # 2. The workflow is triggered by a new release. The tag should be the version of the release.
       - name: Build Docker image
         run: |


### PR DESCRIPTION
## Description

This PR introduces a new GHA workflow `create-release.yml` that automatically performs all steps that were previously done manually by the release manager as parts of the user tasks "Upgrade Zeebe version" (in the pom.xml) and "Create release" (on GitHub):

![image](https://github.com/user-attachments/assets/23356ee2-6319-4853-8c0e-42e44b51ae1f)

![image](https://github.com/user-attachments/assets/4a4052af-f6b0-4709-8b04-402be657d29e)

This change affects 8.3-8.8 since ZPT releases are done identically for all C8 versions.

The goal of this PR is **not** to replace/reengineer the whole `deploy-artifacts` GHA workflow that does the Maven build and upload (too time-consuming compared to value gained) since `deploy-artifacts` works and is also ran `on: push` to `main`.

Instead, this PR only aims to close the gap and automate tasks that are currently manual for smoother release experience (most value). A run of `create-release.yml` will implicitly trigger `deploy-artifacts.yml` at the end.

The new GHA workflow `create-release` can is called from the `zeebe-process-test-release.bpmn` in https://github.com/camunda/zeebe-engineering-processes/pull/557 → removes the need mentioned 2 user tasks.

## Testing

For `create-release` I manually tested by mocking the release branch and vairables to see if the individual steps work and have enough permissions:

* dry-run: https://github.com/camunda/zeebe-process-test/actions/runs/15253189533/job/42894561299
* no dry-run: https://github.com/camunda/zeebe-process-test/actions/runs/15253665687/job/42896122418 triggering https://github.com/camunda/zeebe-process-test/actions/runs/15253679709 (for `deploy-artifacts`)

![image](https://github.com/user-attachments/assets/01cc3020-9a30-45d8-8972-534d3b89ace5)

Produced version bump commit: https://github.com/camunda/zeebe-process-test/commit/d5d694e8556dd9dcccbde99363f9ea6098febff9

![image](https://github.com/user-attachments/assets/220f5eda-76e8-448b-b3fe-8813031c685c)


## Related issues

Related https://github.com/camunda/camunda/issues/31509