### PR TITLE
[backport stable/8.4] ci: do not fail ci on flaky test on macos

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -66,7 +66,12 @@ jobs:
 
       - name: Build
         id: build
-        run: mvn -B -U -pl "-:zeebe-process-test-qa-testcontainers" -P !localBuild "-Dsurefire.rerunFailingTestsCount=5" clean install
+        run: |
+          mvn -B -U -pl "-:zeebe-process-test-qa-testcontainers" \
+            -P !localBuild \
+            "-Dsurefire.rerunFailingTestsCount=5" \
+            "-DfailOnFlakyTest=${{ ! contains(matrix.os, 'macos') }}" \
+            clean install
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v4

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,8 @@
     <dependency.testcontainers.version>1.19.3</dependency.testcontainers.version>
     <dependency.zeebe.version>8.4.19</dependency.zeebe.version>
 
+    <failOnFlakyTest>true</failOnFlakyTest>
+
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
 
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/</nexus.release.repository>
@@ -675,6 +677,9 @@
               <goal>extract-flaky-tests</goal>
             </goals>
             <phase>post-integration-test</phase>
+            <configuration>
+              <failBuild>${failOnFlakyTest}</failBuild>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
# Description
Backport of #1687 to `stable/8.4`.

relates to #1619