### PR TITLE
fix: removal of REDISTRIBUTION value type logger

### DIFF
--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java
@@ -137,7 +137,6 @@ public class RecordStreamLogger {
     valueTypeLoggers.put(ValueType.SCALE, Object::toString);
     valueTypeLoggers.put(ValueType.GROUP, Object::toString);
     valueTypeLoggers.put(ValueType.MAPPING, Object::toString);
-    valueTypeLoggers.put(ValueType.REDISTRIBUTION, Object::toString);
     valueTypeLoggers.put(ValueType.IDENTITY_SETUP, Object::toString);
     valueTypeLoggers.put(ValueType.RESOURCE, Object::toString);
     valueTypeLoggers.put(ValueType.BATCH_OPERATION_CREATION, Object::toString);


### PR DESCRIPTION
## Description

It got removed upstream via https://github.com/camunda/camunda/pull/33048

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
