### PR TITLE
fix: use the correct release version

### DIFF
--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -103,10 +103,10 @@ jobs:
         id: branch
         run: |
           if ! [ -z "${{ github.event.release.tag_name }}" ] && [[ "${{ github.event.release.tag_name }}" != *"alpha"* ]]; then
-            MAJOR_MINOR_VERSION=$(echo ${{ github.event.release.tag_name }} | sed -rn 's/^([0-9]+.[0-9]+).[0-9]+.*$/\1/p')
-            test -z "${MAJOR_MINOR_VERSION}" && echo "::error::Tag ${{ github.event.release.tag_name }} does not adhere to semantic versioning" && exit 1
-            echo "branch=stable/${MAJOR_MINOR_VERSION}" >> $GITHUB_OUTPUT
-            echo "Branch = stable/${MAJOR_MINOR_VERSION}"
+            SEMANTIC_VERSION=$(echo ${{ github.event.release.tag_name }} | sed -rn 's/^([0-9]+.[0-9]+.[0-9]+).*$/\1/p')
+            test -z "${SEMANTIC_VERSION}" && echo "::error::Tag ${{ github.event.release.tag_name }} does not adhere to semantic versioning" && exit 1
+            echo "branch=release-${SEMANTIC_VERSION}" >> $GITHUB_OUTPUT
+            echo "Branch = release-${SEMANTIC_VERSION}"
           else
             echo "branch=${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
             echo "Branch = ${{ github.event.repository.default_branch }}"
@@ -127,7 +127,7 @@ jobs:
           sonatype-central-portal-usr: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}
           sonatype-central-portal-psw: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
           # maven-usr, maven-psw and maven-url are deprecated; they are required only for publishing to the legacy OSS Sonatype repository.
-          # Once the io.zeebe namespace is migrated to the Sonatype Central Portal, these can be safely removed.          
+          # Once the io.zeebe namespace is migrated to the Sonatype Central Portal, these can be safely removed.
           maven-usr: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}
           maven-psw: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
           maven-gpg-passphrase: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}


### PR DESCRIPTION
## Description

For versions `x.y.z` use release branch `release-x.y.z` instead of `stable/x.y`

## Related issues

Discussion: https://camunda.slack.com/archives/C08MRKHJ0CD/p1750941429716289?thread_ts=1750869547.401209&cid=C08MRKHJ0CD

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
