### PR TITLE
Remove value type logger test for 8.6

### DIFF
--- a/filters/src/test/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLoggerTest.java
+++ b/filters/src/test/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLoggerTest.java
@@ -33,9 +33,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Stream;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -52,23 +50,6 @@ class RecordStreamLoggerTest {
     TYPED_TEST_VARIABLES.put("booleanProperty", true);
     TYPED_TEST_VARIABLES.put("complexProperty", Arrays.asList("Element 1", "Element 2"));
     TYPED_TEST_VARIABLES.put("nullProperty", null);
-  }
-
-  @Test
-  void testAllValueTypesAreMapped() {
-    final Map<ValueType, Function<Record<?>, String>> valueTypeLoggers =
-        new RecordStreamLogger(null).getValueTypeLoggers();
-
-    final SoftAssertions softly = new SoftAssertions();
-    Arrays.asList(ValueType.values())
-        .forEach(
-            valueType ->
-                softly
-                    .assertThat(valueTypeLoggers.containsKey(valueType))
-                    .withFailMessage("No value type logger defined for value type '%s'", valueType)
-                    .isTrue());
-
-    softly.assertAll();
   }
 
   @ParameterizedTest(name = "{0}")


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

If no value type logger can be found we log an empty string by default. This is good enough as new value types won't be 
supported in ZPT anymore.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes N/A

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
