### PR TITLE
[Backport release-8.8.0-alpha7] deps: Update dependency org.camunda.community:community-hub-release-parent to v2.1.0 (main)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.camunda.community</groupId>
     <artifactId>community-hub-release-parent</artifactId>
-    <version>2.0.3</version>
+    <version>2.1.0</version>
   </parent>
 
   <groupId>io.camunda</groupId>


### PR DESCRIPTION
# Description
Backport of #1765 to `release-8.8.0-alpha7`.

relates to 