### PR TITLE
[Backport release-8.8.0-alpha8] fix: switch to gRPC endpoints for camunda client

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryEngine.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryEngine.java
@@ -98,6 +98,7 @@ public class InMemoryEngine implements ZeebeTestEngine {
   public CamundaClient createClient() {
     return CamundaClient.newClientBuilder()
         .applyEnvironmentVariableOverrides(false)
+        .preferRestOverGrpc(false)
         .gatewayAddress(getGatewayAddress())
         .usePlaintext()
         .build();
@@ -108,6 +109,7 @@ public class InMemoryEngine implements ZeebeTestEngine {
     return CamundaClient.newClientBuilder()
         .withJsonMapper(new CamundaObjectMapper(objectMapper))
         .applyEnvironmentVariableOverrides(false)
+        .preferRestOverGrpc(false)
         .gatewayAddress(getGatewayAddress())
         .usePlaintext()
         .build();

--- a/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ContainerizedEngine.java
+++ b/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ContainerizedEngine.java
@@ -96,6 +96,7 @@ public class ContainerizedEngine implements ZeebeTestEngine {
   public CamundaClient createClient() {
     return CamundaClient.newClientBuilder()
         .applyEnvironmentVariableOverrides(false)
+        .preferRestOverGrpc(false)
         .gatewayAddress(getGatewayAddress())
         .usePlaintext()
         .build();
@@ -106,6 +107,7 @@ public class ContainerizedEngine implements ZeebeTestEngine {
     return CamundaClient.newClientBuilder()
         .withJsonMapper(new CamundaObjectMapper(objectMapper))
         .applyEnvironmentVariableOverrides(false)
+        .preferRestOverGrpc(false)
         .gatewayAddress(getGatewayAddress())
         .usePlaintext()
         .build();

--- a/spring-test/common/src/main/java/io/camunda/zeebe/spring/test/AbstractZeebeTestExecutionListener.java
+++ b/spring-test/common/src/main/java/io/camunda/zeebe/spring/test/AbstractZeebeTestExecutionListener.java
@@ -76,6 +76,7 @@ public class AbstractZeebeTestExecutionListener {
     // (https://github.com/camunda-community-hub/spring-zeebe/blob/11966be454cc76f3966fb2c0e4114a35487946fc/client/spring-zeebe-starter/src/main/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfiguration.java#L30)?
     final CamundaClientBuilder builder =
         CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(false)
             .gatewayAddress(zeebeEngine.getGatewayAddress())
             .usePlaintext();
     if (testContext.getApplicationContext().getBeanNamesForType(JsonMapper.class).length > 0) {


### PR DESCRIPTION
# Description
Backport of #1845 to `release-8.8.0-alpha8`.

relates to 