### PR TITLE
fix: Skip pushing git changes in dryRun mode

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,8 +1,42 @@
 ---
 name: Create Release
 
-# Used by https://github.com/camunda/zeebe-engineering-processes/blob/main/src/main/resources/release/zeebe-process-test-release.bpmn
 on:
+  # Used for standalone testing
+  workflow_call:
+    inputs:
+      releaseVersion:
+        description: 'releaseVersion: e.g. MAJOR.MINOR.PATCH[-ALPHAn]'
+        type: string
+        required: true
+      minorVersion:
+        description: 'minorVersion: just the MAJOR.MINOR part of the releaseVersion'
+        type: string
+        required: true
+      releaseType:
+        description: 'releaseType: e.g. minor, alpha or patch'
+        type: string
+        required: true
+      nextDevelopmentVersion:
+        description: 'nextDevelopmentVersion: e.g. 8.X.X-SNAPSHOT'
+        type: string
+        required: true
+      isLatest:
+        description: 'isLatest: updates the `latest` docker tag'
+        type: boolean
+        required: false
+        default: false
+      releaseBranch:
+        description: 'releaseBranch: defaults to `release-$releaseVersion` if not set'
+        type: string
+        required: false
+        default: ''
+      dryRun:
+        description: 'dryRun: Whether to perform a dry release where no changes/artifacts are pushed'
+        type: boolean
+        required: true
+        default: false
+  # Used by https://github.com/camunda/zeebe-engineering-processes/blob/main/src/main/resources/release/zeebe-process-test-release.bpmn
   workflow_dispatch:
     inputs:
       releaseVersion:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -85,7 +85,7 @@ jobs:
       MINOR_VERSION: ${{ inputs.minorVersion }}
     steps:
       - name: Output inputs
-        run: echo "${{ toJSON(github.event.inputs) }}"
+        run: echo "${{ toJSON(inputs) }}"
 
       # This step generates a GitHub App token to be used in Git operations as a workaround  for
       # the known GitHub issue described in https://github.com/camunda/camunda/issues/28522

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Create new stable branch for minor
         if: ${{ inputs.releaseType == 'minor' }}
         run: |
-          git checkout --branch "stable/${MINOR_VERSION}"
+          git checkout -b "stable/${MINOR_VERSION}"
 
       - name: Push new stable branch for minor
         if: ${{ inputs.releaseType == 'minor' && inputs.dryRun == false }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -113,6 +113,10 @@ jobs:
         if: ${{ inputs.releaseType == 'minor' }}
         run: |
           git checkout --branch "stable/${MINOR_VERSION}"
+
+      - name: Push new stable branch for minor
+        if: ${{ inputs.releaseType == 'minor' && inputs.dryRun == false }}
+        run: |
           git push origin "stable/${MINOR_VERSION}"
 
       # Same logic as in camunda/camunda


### PR DESCRIPTION
## Description

This change fixes few issues in `create-release.yml` workflow:
- Skip pushing git changes in dryRun mode
- Fix `stable/${MINOR_VERSION}` branch creation

Besides `on:workflow_call` added into `create-release.yml` in order to enable standalone testing of the workflow. Also `Output inputs` step was enhanced to handle such scenario.

## Related issues

https://github.com/camunda/camunda/issues/28529

closes #

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatible with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] The behavior is tested manually

Test evidence:

1. Successful execution for minor version

https://github.com/camunda/zeebe-process-test/actions/runs/17385643545/job/49351514018

<img width="1717" height="874" alt="image" src="https://github.com/user-attachments/assets/3bf8d84c-a77b-4002-8fc6-04169329469e" />

2. Successful execution for alpha version

https://github.com/camunda/zeebe-process-test/actions/runs/17385539137/job/49351248202

<img width="1716" height="856" alt="image" src="https://github.com/user-attachments/assets/723a81a6-77d0-4566-b6bd-780eef1f6410" />
