### PR TITLE
fix: obtain Zeebe In-Memory engine port from ServerSocket

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
@@ -36,8 +36,11 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.List;
 import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class EngineFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(EngineFactory.class);
 
   public static ZeebeTestEngine create() {
     return create(findFreePort());
@@ -47,6 +50,7 @@ public class EngineFactory {
     final int freePort;
     try (final var serverSocket = new ServerSocket(0)) {
       freePort = serverSocket.getLocalPort();
+      LOG.info("Obtained free port for Zeebe in-memory engine from ephemeral range: {}", freePort);
     } catch (final IOException e) {
       throw new RuntimeException(e);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -507,6 +507,15 @@
     </dependencies>
   </dependencyManagement>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.16</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <repositories>
     <repository>
       <releases>

--- a/pom.xml
+++ b/pom.xml
@@ -659,6 +659,9 @@
             <configuration>
               <failOnWarning>true</failOnWarning>
               <skip>${skipChecks}</skip>
+              <ignoredUnusedDeclaredDependencies>
+                <dependency>org.slf4j:slf4j-simple:jar:2.0.16</dependency>
+              </ignoredUnusedDeclaredDependencies>
             </configuration>
           </execution>
         </executions>
@@ -723,6 +726,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${plugin.version.surefire}</version>
+        <configuration>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
+        </configuration>
       </plugin>
 
       <!-- Flaky Tests plugin -->

--- a/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
+++ b/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
@@ -24,7 +24,6 @@ import org.springframework.core.Ordered;
 import org.springframework.lang.NonNull;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
-import org.springframework.test.util.TestSocketUtils;
 
 /** Test execution listener binding the Zeebe engine to current test context. */
 public class ZeebeTestExecutionListener extends AbstractZeebeTestExecutionListener
@@ -35,20 +34,18 @@ public class ZeebeTestExecutionListener extends AbstractZeebeTestExecutionListen
 
   private ZeebeTestEngine zeebeEngine;
 
-  public void beforeTestMethod(@NonNull TestContext testContext) {
-    int randomPort =
-        TestSocketUtils
-            .findAvailableTcpPort(); // can be replaced with TestSocketUtils once available:
-    // https://github.com/spring-projects/spring-framework/pull/29132
-
-    LOGGER.info("Create Zeebe in-memory engine for test run on random port: " + randomPort + "...");
-    zeebeEngine = EngineFactory.create(randomPort);
+  @Override
+  public void beforeTestMethod(@NonNull final TestContext testContext) {
+    LOGGER.info("Creating Zeebe in-memory engine...");
+    zeebeEngine = EngineFactory.create();
     zeebeEngine.start();
+    LOGGER.info("Successfully started Zeebe in-memory engine.");
 
     setupWithZeebeEngine(testContext, zeebeEngine);
   }
 
-  public void afterTestMethod(@NonNull TestContext testContext) {
+  @Override
+  public void afterTestMethod(@NonNull final TestContext testContext) {
     cleanup(testContext, zeebeEngine);
     zeebeEngine.stop();
   }


### PR DESCRIPTION
## Description

Previously the grpc port was selected using the Spring [TestSocketUtils](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/test/util/TestSocketUtils.html), the docs of this util don't sound very promising though:

>However, these utilities make no guarantee about the subsequent availability of a given port and are therefore unreliable. Instead of using TestSocketUtils to find an available local port for a server, it is recommended that you rely on a server's ability to start on a random ephemeral port that it selects or is assigned by the operating system.

After changing this to delegate the selection to the JVM/OS, [ 30 runs succeeded straight](https://github.com/camunda/zeebe-process-test/actions/workflows/snapshot-test.yml?query=branch%3Ameg-port-collision-debug) 🤞 

The commits on test logging, have the effect that we have the surefire `*-output.txt` files saved, previous surefire report archives were not useful as they lacked the log output.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates #1661

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
