### PR TITLE
[backport stable/8.7] fix: add missing space separating two words in error message

### DIFF
--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/IncidentLogger.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/IncidentLogger.java
@@ -68,7 +68,7 @@ public class IncidentLogger {
       stringBuilder
           .append(System.lineSeparator())
           .append(
-              "If you did not expect any incidents to occur, then we recommend investigating"
+              "If you did not expect any incidents to occur, then we recommend investigating "
                   + "these. These incidents may indicate what went wrong in your test case")
           .append(System.lineSeparator());
     }


### PR DESCRIPTION
## Description

Backport of #1868 
