### PR TITLE
ci: adjustment for 8.8 minor release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -143,16 +143,6 @@ jobs:
         run: |
           git push origin "${RELEASE_VERSION}"
 
-      - name: Create new stable branch for minor
-        if: ${{ inputs.releaseType == 'minor' }}
-        run: |
-          git checkout -b "stable/${MINOR_VERSION}"
-
-      - name: Push new stable branch for minor
-        if: ${{ inputs.releaseType == 'minor' && inputs.dryRun == false }}
-        run: |
-          git push origin "stable/${MINOR_VERSION}"
-
       # Same logic as in camunda/camunda
       - name: Determine if pre-release
         id: pre-release


### PR DESCRIPTION
## Description

Since the `stable/8.8` branch already exists, we want to avoid failure in the ZPT release automation when it would try to create it again on the next 8.8 minor release.

## Related issues

Related to https://github.com/camunda/camunda/issues/38074