### PR TITLE
[Backport stable/8.8] fix: adapt to upstream changes on InterPartitionCommandSender

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/CommandSender.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/CommandSender.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.process.test.engine;
 
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -39,6 +40,17 @@ final class CommandSender implements InterPartitionCommandSender {
       final Intent intent,
       final Long recordKey,
       final UnifiedRecordValue command) {
+    sendCommand(receiverPartitionId, valueType, intent, recordKey, command, null);
+  }
+
+  @Override
+  public void sendCommand(
+      final int receiverPartitionId,
+      final ValueType valueType,
+      final Intent intent,
+      final Long recordKey,
+      final UnifiedRecordValue command,
+      final AuthInfo authInfo) {
     final RecordMetadata metadata =
         new RecordMetadata().recordType(RecordType.COMMAND).intent(intent).valueType(valueType);
     writer.writeCommandWithKey(recordKey, command, metadata);

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <dependency.snakeyaml.version>2.4</dependency.snakeyaml.version>
     <dependency.spring-boot.version>3.5.6</dependency.spring-boot.version>
     <dependency.testcontainers.version>1.21.3</dependency.testcontainers.version>
-    <dependency.zeebe.version>8.8.0</dependency.zeebe.version>
+    <dependency.zeebe.version>8.8.1</dependency.zeebe.version>
 
     <failOnFlakyTest>true</failOnFlakyTest>
 


### PR DESCRIPTION
# Description
Backport of #1908 to `stable/8.8`.

relates to 