### PR TITLE
ci: Revert adjustment for 8.8 minor release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -143,6 +143,16 @@ jobs:
         run: |
           git push origin "${RELEASE_VERSION}"
 
+      - name: Create new stable branch for minor
+        if: ${{ inputs.releaseType == 'minor' }}
+        run: |
+          git checkout -b "stable/${MINOR_VERSION}"
+
+      - name: Push new stable branch for minor
+        if: ${{ inputs.releaseType == 'minor' && inputs.dryRun == false }}
+        run: |
+          git push origin "stable/${MINOR_VERSION}"
+
       # Same logic as in camunda/camunda
       - name: Determine if pre-release
         id: pre-release


### PR DESCRIPTION
This reverts commit 7fd3aa1b8a55cd282bbd924d80f7ee635a1fe5c7.

## Description
This pull request updates the release workflow to automatically create and push a new stable branch when a minor release is performed. This helps maintain a stable branch for each minor version, streamlining version management.

Release workflow improvements:

* Added steps to create a new `stable/${MINOR_VERSION}` branch when the release type is minor in `.github/workflows/create-release.yml`.
* Added logic to push the new stable branch to the remote repository only if not running in dry run mode.

## Related issues

https://github.com/camunda/zeebe-process-test/pull/1882
context: https://github.com/camunda/camunda/issues/38673

closes #

