### PR TITLE
[Backport release-8.9.0-alpha1] fix: implement missing method

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbFactory.java
@@ -22,6 +22,11 @@ public class InMemoryDbFactory<
   }
 
   @Override
+  public ZeebeDb<ColumnFamilyType> createDb(final File pathName, final boolean avoidFlush) {
+    return createDb(pathName);
+  }
+
+  @Override
   public ZeebeDb<ColumnFamilyType> createDb(final File pathName) {
     return new InMemoryDb<>();
   }


### PR DESCRIPTION
# Description
Backport of #1919 to `release-8.9.0-alpha1`.

relates to 