### PR TITLE
fix: new rpc methods are not supported by ZPT as the project is deprecated in favour of CPT

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGatewayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGatewayTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class GrpcToLogStreamGatewayTest {
 
-  static final List<String> UNSUPPORTED_METHODS = List.of();
+  static final List<String> UNSUPPORTED_METHODS = List.of("evaluateConditional");
 
   static final List<String> IGNORED_METHODS =
       List.of(


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

New RPC method `evaluateConditional` is not supported in ZPT, as the project is deprecated from 8.8
