### PR TITLE
ci: spring boot 4.0 compatibility job

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -43,7 +43,7 @@ jobs:
         run: mvn license:check
 
   build-and-test-embedded:
-    name: Run tests on ${{ matrix.os }}
+    name: Run tests on ${{ matrix.os }} and Spring-Boot ${{ matrix.spring-boot-version }}
     timeout-minutes: 15
     needs: code-formatting
     runs-on: ${{ matrix.os }}
@@ -52,6 +52,8 @@ jobs:
       max-parallel: 3
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
+        # Note: `3.5` is an invalid profile just serving as a placeholder for the default version.
+        spring-boot-version: [ 3.5, 4.0]
 
     steps:
       - name: Checkout
@@ -68,7 +70,7 @@ jobs:
         id: build
         run: |
           mvn -B -U -pl "-:zeebe-process-test-qa-testcontainers,-:spring-boot-starter-camunda-test-testcontainer" \
-            -P !localBuild \
+            -P !localBuild,spring-boot-${{ matrix.spring-boot-version }} \
             "-Dsurefire.rerunFailingTestsCount=5" \
             "-DfailOnFlakyTest=${{ ! contains(matrix.os, 'macos') }}" \
             clean install
@@ -77,15 +79,21 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: Unit Test Results ${{ matrix.os }}
+          name: "Unit Test Results ${{ matrix.os }} with Spring-Boot ${{ matrix.spring-boot-version }}"
           path: "**/target/surefire-reports/"
           retention-days: 7
 
   build-and-test-testcontainers:
-    name: Run tests on ubuntu-latest using testcontainers
+    name: Run tests on ubuntu-latest using testcontainers and spring-boot ${{ matrix.spring-boot-version }}
     timeout-minutes: 15
     needs: code-formatting
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        # Note: `default` is an invalid profile just serving as a placeholder with no effect.
+        spring-boot-version: [ default, 4.0 ]
     env:
       IMAGE_NAME: "qa-tests"
 
@@ -121,13 +129,16 @@ jobs:
       - name: Build
         id: build
         run: |
-          mvn clean -B -U -pl ":zeebe-process-test-qa-testcontainers,:spring-boot-starter-camunda-test-testcontainer" -P !localBuild -am "-Dsurefire.rerunFailingTestsCount=5" install -DskipChecks
+          mvn clean -B -U -pl ":zeebe-process-test-qa-testcontainers,:spring-boot-starter-camunda-test-testcontainer"  \
+            -P !localBuild,spring-boot-${{ matrix.spring-boot-version }}  \
+            -am "-Dsurefire.rerunFailingTestsCount=5" -DskipChecks \
+            install
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: Unit Test Results Testcontainers
+          name: "Unit Test Results Testcontainers with Spring-Boot ${{ matrix.spring-boot-version }}"
           path: "**/target/surefire-reports/"
           retention-days: 7
 

--- a/spring-test/pom.xml
+++ b/spring-test/pom.xml
@@ -68,4 +68,13 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>spring-boot-4.0</id>
+      <properties>
+        <dependency.spring-boot.version>4.0.1</dependency.spring-boot.version>
+      </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
## Description

Adds spring-boot version maven profile toggled on via a matrix job to assess spring-boot 4.0
version compatibility.

I could verify compatibility manually with the existing module but using spring-boot 4 in a project see https://github.com/camunda-community-hub/camunda-8-examples/commit/2b86a8cedb377efcc691e072854cb11cd04428f4 would thus not go for a dedicated 4 module on this deprecated project but only do the compatibility check by compiling and testing against 4 in the CI.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates https://github.com/camunda/camunda/issues/42077

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
