### PR TITLE
fix: DbNullKey.write return int

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/DbNullKey.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/DbNullKey.java
@@ -29,7 +29,8 @@ final class DbNullKey implements DbKey {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     // do nothing
+    return 0;
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

DbNullKey.write return int

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://camunda.slack.com/archives/C0A2AGG2Q2E/p1771386579424519
