### PR TITLE
[Backport stable/8.8] fix: DbNullKey.write return int

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/DbNullKey.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/DbNullKey.java
@@ -29,7 +29,8 @@ final class DbNullKey implements DbKey {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     // do nothing
+    return 0;
   }
 }


### PR DESCRIPTION
# Description
Backport of #2054 to `stable/8.8`.

relates to 