### PR TITLE
fix: Implement whileTrueReverse for InMemoryDbColumnFamily

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbIterator.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbIterator.java
@@ -9,21 +9,36 @@ package io.camunda.zeebe.process.test.engine.db;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.SortedMap;
 
 final class InMemoryDbIterator {
 
-  private final SortedMap<Bytes, Bytes> database;
+  private final NavigableMap<Bytes, Bytes> database;
 
   InMemoryDbIterator(final SortedMap<Bytes, Bytes> database) {
-    this.database = database;
+    if (database instanceof NavigableMap) {
+      this.database = (NavigableMap<Bytes, Bytes>) database;
+    } else {
+      this.database = new java.util.TreeMap<>(database);
+    }
   }
 
   InMemoryDbIterator seek(final byte[] prefixedKey, final int prefixLength) {
-    return new InMemoryDbIterator(database.tailMap(Bytes.fromByteArray(prefixedKey, prefixLength)));
+    return new InMemoryDbIterator(
+        database.tailMap(Bytes.fromByteArray(prefixedKey, prefixLength), true));
+  }
+
+  InMemoryDbIterator seekReverse(final byte[] prefixedKey, final int prefixLength) {
+    final Bytes seekKey = Bytes.fromByteArray(prefixedKey, prefixLength);
+    return new InMemoryDbIterator(database.headMap(seekKey, true));
   }
 
   Iterator<Map.Entry<Bytes, Bytes>> iterate() {
     return database.entrySet().iterator();
+  }
+
+  Iterator<Map.Entry<Bytes, Bytes>> iterateReverse() {
+    return database.descendingMap().entrySet().iterator();
   }
 }

--- a/spring-test/embedded/src/test/java/io/camunda/zeebe/spring/client/jobhandling/JobHandlerTest.java
+++ b/spring-test/embedded/src/test/java/io/camunda/zeebe/spring/client/jobhandling/JobHandlerTest.java
@@ -25,8 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.camunda.client.annotation.customizer.JobWorkerValueCustomizer;
 import io.camunda.client.annotation.value.JobWorkerValue;
-import io.camunda.client.annotation.value.JobWorkerValue.SourceAware;
-import io.camunda.client.annotation.value.JobWorkerValue.SourceAware.FromOverrideProperty;
+import io.camunda.client.annotation.value.SourceAware;
+import io.camunda.client.annotation.value.SourceAware.FromOverrideProperty;
 import io.camunda.client.jobhandling.JobWorkerManager;
 import io.camunda.client.spring.configuration.MetricsDefaultConfiguration;
 import io.camunda.zeebe.client.ZeebeClient;


### PR DESCRIPTION
## Description

Adapt to upstream change introduced in camunda/camunda#46441 by implementing the whileTrueReverse method in the in-memory column family and adding reverse seek/iteration support to InMemoryDbIterator.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
