### PR TITLE
[Backport stable/8.8] fix: process annotations on test class for @Deployment and @JobWorker

### DIFF
--- a/spring-test/common/pom.xml
+++ b/spring-test/common/pom.xml
@@ -24,6 +24,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>

--- a/spring-test/embedded/src/test/java/io/camunda/zeebe/spring/client/jobhandling/DeploymentAnnotationOnTestClassTest.java
+++ b/spring-test/embedded/src/test/java/io/camunda/zeebe/spring/client/jobhandling/DeploymentAnnotationOnTestClassTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2021 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.spring.client.jobhandling;
+
+import static io.camunda.zeebe.spring.test.ZeebeTestThreadSupport.waitForProcessInstanceCompleted;
+
+import io.camunda.client.annotation.Deployment;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.spring.test.ZeebeSpringTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * Regression test verifying that a {@link Deployment} annotation placed directly on a {@link
+ * SpringBootTest} test class is picked up and the specified resources are deployed. This was broken
+ * in the 8.8 refactoring where annotation processing switched from a {@code BeanPostProcessor}
+ * (which sees all objects including test instances) to iterating {@code
+ * ApplicationContext.getBeanDefinitionNames()} (which does not include test classes).
+ */
+@SpringBootTest(classes = DeploymentAnnotationOnTestClassTest.class)
+@ZeebeSpringTest
+@Deployment(resources = "classpath:deployment-annotation-test.bpmn")
+public class DeploymentAnnotationOnTestClassTest {
+
+  @Autowired private ZeebeClient client;
+
+  @Test
+  void testProcessDeployedViaClassLevelAnnotation() {
+    // If @Deployment on the test class was not processed, this will fail with
+    // "Command 'CREATE' rejected: Expected to find process definition with process ID
+    // 'deploymentAnnotationTestProcess', but none found"
+    final ProcessInstanceEvent processInstance =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId("deploymentAnnotationTestProcess")
+            .latestVersion()
+            .send()
+            .join();
+
+    waitForProcessInstanceCompleted(processInstance);
+  }
+}

--- a/spring-test/embedded/src/test/java/io/camunda/zeebe/spring/client/jobhandling/JobWorkerAnnotationOnTestClassTest.java
+++ b/spring-test/embedded/src/test/java/io/camunda/zeebe/spring/client/jobhandling/JobWorkerAnnotationOnTestClassTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2021 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.spring.client.jobhandling;
+
+import static io.camunda.zeebe.spring.test.ZeebeTestThreadSupport.waitForProcessInstanceCompleted;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.annotation.JobWorker;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.spring.test.ZeebeSpringTest;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * Regression test verifying that a {@link JobWorker} annotation placed directly on a method of a
+ * {@link SpringBootTest} test class is picked up and the worker is registered. This was broken in
+ * the 8.8 refactoring where annotation processing switched from a {@code BeanPostProcessor} (which
+ * sees all objects including test instances) to iterating {@code
+ * ApplicationContext.getBeanDefinitionNames()} (which does not include test classes).
+ */
+@SpringBootTest(classes = JobWorkerAnnotationOnTestClassTest.class)
+@ZeebeSpringTest
+public class JobWorkerAnnotationOnTestClassTest {
+
+  private static final AtomicBoolean WORKER_CALLED = new AtomicBoolean(false);
+
+  @Autowired private ZeebeClient client;
+
+  @JobWorker(type = "testClassWorkerType", autoComplete = true)
+  public void handleJob(final ActivatedJob job) {
+    WORKER_CALLED.set(true);
+  }
+
+  @Test
+  void testJobWorkerOnTestClassMethodIsRegistered() {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("jobWorkerTestProcess")
+            .startEvent()
+            .serviceTask()
+            .zeebeJobType("testClassWorkerType")
+            .endEvent()
+            .done();
+
+    client.newDeployResourceCommand().addProcessModel(process, "jobWorkerTest.bpmn").send().join();
+
+    final ProcessInstanceEvent processInstance =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId("jobWorkerTestProcess")
+            .latestVersion()
+            .send()
+            .join();
+
+    waitForProcessInstanceCompleted(processInstance);
+
+    assertThat(WORKER_CALLED).isTrue();
+  }
+}

--- a/spring-test/embedded/src/test/resources/deployment-annotation-test.bpmn
+++ b/spring-test/embedded/src/test/resources/deployment-annotation-test.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  id="Definitions_1"
+                  targetNamespace="http://bpmn.io/schema/bpmn"
+                  exporter="Camunda Modeler"
+                  exporterVersion="5.0.0">
+  <bpmn:process id="deploymentAnnotationTestProcess" name="Deployment Annotation Test" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="deploymentAnnotationTestProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="265" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint xmlns:di="http://www.omg.org/spec/DD/20100524/DI" x="215" y="97" />
+        <di:waypoint xmlns:di="http://www.omg.org/spec/DD/20100524/DI" x="265" y="97" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
# Description
Backport of #2077 to `stable/8.8`.

relates to camunda/camunda#46557