### PR TITLE
feat: Add message sending to C8 about release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -202,7 +202,7 @@ jobs:
           exportEnv: false # we rely on step outputs, no need for environment variables
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
-            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG_SZPRAAT_TEST | clientConfig
+            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG | clientConfig
 
       - name: Report release result to C8
         uses: camunda-community-hub/camunda-platform-8-github-action@8.3.0
@@ -214,7 +214,7 @@ jobs:
           variables: |
             {
               "is_zpt_release_successful": "${{ needs.create-release.result == 'success' }}",
-              "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "zpt_workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
 
       - name: Send failure Slack notification

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -205,7 +205,7 @@ jobs:
             secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG | clientConfig
 
       - name: Report release result to C8
-        uses: camunda-community-hub/camunda-platform-8-github-action@8.3.0
+        uses: camunda-community-hub/camunda-platform-8-github-action@0fe490e4cf6f0cf59a5c86a127c4354b4b1fc3b7 # 8.3.0
         with:
           clientConfig: ${{ steps.secrets.outputs.clientConfig }}
           operation: publishMessage

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -183,14 +183,11 @@ jobs:
           prerelease: ${{ steps.pre-release.outputs.result }}
           makeLatest: ${{ inputs.isLatest }}
           token: ${{ steps.github-token.outputs.token }}
-
-  notify-if-failed:
-    name: Send Slack notification on failure
+  notify:
+    name: Send notifications
     runs-on: ubuntu-latest
     needs: [create-release]
-    # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
-    # else => send slack notification as an actual release failed
-    if: ${{ failure() && inputs.dryRun == false }}
+    if: ${{ always() }}
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
@@ -205,8 +202,23 @@ jobs:
           exportEnv: false # we rely on step outputs, no need for environment variables
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG_SZPRAAT_TEST | clientConfig
+
+      - name: Report release result to C8
+        uses: camunda-community-hub/camunda-platform-8-github-action@8.3.0
+        with:
+          clientConfig: ${{ steps.secrets.outputs.clientConfig }}
+          operation: publishMessage
+          messageName: Release result in ZPT
+          correlationKey: ${{ inputs.releaseVersion }}
+          variables: |
+            {
+              "is_zpt_release_successful": "${{ needs.create-release.result == 'success' }}",
+              "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
 
       - name: Send failure Slack notification
+        if: ${{ needs.create-release.result == 'failure' && inputs.dryRun == false }}
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -202,7 +202,7 @@ jobs:
           exportEnv: false # we rely on step outputs, no need for environment variables
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
-            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG_SZPRAAT_TEST | clientConfig
+            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG | clientConfig
 
       - name: Report release result to C8
         uses: camunda-community-hub/camunda-platform-8-github-action@8.3.0

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -202,7 +202,7 @@ jobs:
           exportEnv: false # we rely on step outputs, no need for environment variables
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
-            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG | clientConfig
+            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG_SZPRAAT_TEST | clientConfig
 
       - name: Report release result to C8
         uses: camunda-community-hub/camunda-platform-8-github-action@8.3.0

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -197,7 +197,7 @@ jobs:
           exportEnv: false # we rely on step outputs, no need for environment variables
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
-            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG | clientConfig
+            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG_SZPRAAT_TEST | clientConfig
 
       - name: Report deploy result to C8
         uses: camunda-community-hub/camunda-platform-8-github-action@8.3.0

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -17,8 +17,7 @@ on:
       releaseVersion:
         description: 'releaseVersion: e.g. MAJOR.MINOR.PATCH[-ALPHAn]'
         type: string
-        required: false
-        default: ''
+        required: true
 
 jobs:
   test:
@@ -82,7 +81,7 @@ jobs:
           mvn clean package -DskipTests -P !localBuild -pl :zeebe-process-test-engine-agent -am
 
         # We build a docker image with a specific tag. There are 3 possible scenarios here.
-        # 1. The workflow is triggered via workflow_call/dispatch with releaseVersion input.
+        # 1. The workflow is triggered via workflow_dispatch with releaseVersion input.
         # 2. The workflow is triggered by a new release. The tag should be the version of the release.
         # 3. The workflow is triggered by a change on the main branch. The tag should be equal to the project.version.
       - name: Build Docker image

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -196,6 +196,20 @@ jobs:
           exportEnv: false # we rely on step outputs, no need for environment variables
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG | clientConfig
+      - name: Report release success to C8
+        if: success()  
+        uses: camunda-community-hub/camunda-platform-8-github-action@8.3.0
+        with:
+          clientConfig: ${{ steps.secrets.outputs.clientConfig }}
+          operation: publishMessage
+          messageName: Release result in ZPT
+          correlationKey: ${{ inputs.releaseVersion }}
+          variables: |
+            {
+              "is_zpt_release_successful": "true",
+              "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
 
       - name: Send success Slack notification
         if: ${{ needs.deploy.result == 'success' && github.event_name == 'release' }}
@@ -217,6 +231,19 @@ jobs:
               ]
             }
 
+      - name: Report release success to C8
+        if: failure()  
+        uses: camunda-community-hub/camunda-platform-8-github-action@8.3.0
+        with:
+          clientConfig: ${{ steps.secrets.outputs.clientConfig }}
+          operation: publishMessage
+          messageName: Release result in ZPT
+          correlationKey: ${{ inputs.releaseVersion }}
+          variables: |
+            {
+              "is_zpt_release_successful": "false",
+              "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
       - name: Send failure Slack notification
         if: ${{ needs.deploy.result == 'failure' && github.event_name == 'release' }}
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -182,7 +182,7 @@ jobs:
     name: Send notifications
     runs-on: ubuntu-latest
     needs: [deploy]
-    if: ${{ always() }}
+    if: ${{ always() && github.event_name != 'push' }}
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
@@ -205,7 +205,7 @@ jobs:
           clientConfig: ${{ steps.secrets.outputs.clientConfig }}
           operation: publishMessage
           messageName: Deploy result in ZPT
-          correlationKey: ${{ inputs.releaseVersion }}
+          correlationKey: ${{ inputs.releaseVersion || github.event.release.tag_name }}
           variables: |
             {
               "is_deploy_artifact_successful": "${{ needs.deploy.result == 'success' }}",

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -197,7 +197,7 @@ jobs:
           exportEnv: false # we rely on step outputs, no need for environment variables
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
-            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG_SZPRAAT_TEST | clientConfig
+            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG | clientConfig
 
       - name: Report deploy result to C8
         uses: camunda-community-hub/camunda-platform-8-github-action@8.3.0

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -197,9 +197,9 @@ jobs:
           exportEnv: false # we rely on step outputs, no need for environment variables
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
-            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG_SZPRAAT_TEST | clientConfig
-      - name: Report release success to C8
-        if: success()  
+            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG | clientConfig
+
+      - name: Report deploy result to C8
         uses: camunda-community-hub/camunda-platform-8-github-action@8.3.0
         with:
           clientConfig: ${{ steps.secrets.outputs.clientConfig }}
@@ -208,8 +208,8 @@ jobs:
           correlationKey: ${{ inputs.releaseVersion }}
           variables: |
             {
-              "is_deploy_artifact_successful": "true",
-              "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "is_deploy_artifact_successful": "${{ needs.deploy.result == 'success' }}",
+              "zpt_workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
 
       - name: Send success Slack notification
@@ -232,19 +232,6 @@ jobs:
               ]
             }
 
-      - name: Report release success to C8
-        if: failure()  
-        uses: camunda-community-hub/camunda-platform-8-github-action@8.3.0
-        with:
-          clientConfig: ${{ steps.secrets.outputs.clientConfig }}
-          operation: publishMessage
-          messageName: Deploy result in ZPT
-          correlationKey: ${{ inputs.releaseVersion }}
-          variables: |
-            {
-              "is_deploy_artifact_successful": "false",
-              "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }
       - name: Send failure Slack notification
         if: ${{ needs.deploy.result == 'failure' && github.event_name == 'release' }}
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -196,7 +196,7 @@ jobs:
           exportEnv: false # we rely on step outputs, no need for environment variables
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
-            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG | clientConfig
+            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG_SZPRAAT_TEST | clientConfig
       - name: Report release success to C8
         if: success()  
         uses: camunda-community-hub/camunda-platform-8-github-action@8.3.0
@@ -207,7 +207,7 @@ jobs:
           correlationKey: ${{ inputs.releaseVersion }}
           variables: |
             {
-              "is_zpt_release_successful": "true",
+              "is_deploy_artifact_successful": "true",
               "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
 
@@ -241,7 +241,7 @@ jobs:
           correlationKey: ${{ inputs.releaseVersion }}
           variables: |
             {
-              "is_zpt_release_successful": "false",
+              "is_deploy_artifact_successful": "false",
               "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
       - name: Send failure Slack notification

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -203,7 +203,7 @@ jobs:
         with:
           clientConfig: ${{ steps.secrets.outputs.clientConfig }}
           operation: publishMessage
-          messageName: Release result in ZPT
+          messageName: Deploy result in ZPT
           correlationKey: ${{ inputs.releaseVersion }}
           variables: |
             {
@@ -237,7 +237,7 @@ jobs:
         with:
           clientConfig: ${{ steps.secrets.outputs.clientConfig }}
           operation: publishMessage
-          messageName: Release result in ZPT
+          messageName: Deploy result in ZPT
           correlationKey: ${{ inputs.releaseVersion }}
           variables: |
             {

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -199,7 +199,7 @@ jobs:
             secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG | clientConfig
 
       - name: Report deploy result to C8
-        uses: camunda-community-hub/camunda-platform-8-github-action@8.3.0
+        uses: camunda-community-hub/camunda-platform-8-github-action@0fe490e4cf6f0cf59a5c86a127c4354b4b1fc3b7 # 8.3.0
         with:
           clientConfig: ${{ steps.secrets.outputs.clientConfig }}
           operation: publishMessage

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   test:
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     uses: ./.github/workflows/build-test.yml
     secrets: inherit
 


### PR DESCRIPTION
## Description

This PR is part of the [Release: defer the Maven Central publishing steps towards the very end of the process](https://github.com/camunda/camunda/issues/41324) ticket

## Changes

Two new steps are added, where paralelly with the success/failure slack message, a message is sent to C8 cluster notifying about the result so the release workflow will be able to move forward based on the result.

Additionally dry-run capability is added for both workflows as it was needed to test the workflow properly.


## Related issues
https://github.com/camunda/camunda/issues/41324
closes #
