### PR TITLE
fix: implement key-only iteration methods in InMemoryDbColumnFamily

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbColumnFamily.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/db/InMemoryDbColumnFamily.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.DbKey;
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.db.KeyValuePairVisitor;
+import io.camunda.zeebe.db.KeyVisitor;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDbInconsistentException;
 import io.camunda.zeebe.protocol.ColumnFamilyScope;
@@ -175,6 +176,56 @@ final class InMemoryDbColumnFamily<
       final KeyType startAtKey, final KeyValuePairVisitor<KeyType, ValueType> visitor) {
     whileEqualPrefixReverse(
         context, startAtKey, DbNullKey.INSTANCE, keyInstance, valueInstance, visitor);
+  }
+
+  @Override
+  public void forEachKey(final Consumer<KeyType> consumer) {
+    whileEqualPrefixKeyOnly(
+        context,
+        DbNullKey.INSTANCE,
+        keyInstance,
+        key -> {
+          consumer.accept(key);
+          return true;
+        });
+  }
+
+  @Override
+  public void whileTrue(final KeyVisitor<KeyType> visitor) {
+    whileEqualPrefixKeyOnly(context, DbNullKey.INSTANCE, keyInstance, visitor);
+  }
+
+  @Override
+  public void whileTrue(final KeyType startAtKey, final KeyVisitor<KeyType> visitor) {
+    whileEqualPrefixKeyOnly(context, startAtKey, DbNullKey.INSTANCE, keyInstance, visitor);
+  }
+
+  @Override
+  public void whileEqualPrefix(final DbKey keyPrefix, final Consumer<KeyType> consumer) {
+    whileEqualPrefixKeyOnly(
+        context,
+        keyPrefix,
+        keyInstance,
+        key -> {
+          consumer.accept(key);
+          return true;
+        });
+  }
+
+  @Override
+  public void whileEqualPrefix(final DbKey keyPrefix, final KeyVisitor<KeyType> visitor) {
+    whileEqualPrefixKeyOnly(context, keyPrefix, keyInstance, visitor);
+  }
+
+  @Override
+  public void whileEqualPrefix(
+      final DbKey keyPrefix, final KeyType startAtKey, final KeyVisitor<KeyType> visitor) {
+    whileEqualPrefixKeyOnly(context, startAtKey, keyPrefix, keyInstance, visitor);
+  }
+
+  @Override
+  public void whileTrueReverse(final KeyType startAtKey, final KeyVisitor<KeyType> visitor) {
+    whileEqualPrefixReverseKeyOnly(context, startAtKey, DbNullKey.INSTANCE, keyInstance, visitor);
   }
 
   @Override
@@ -401,6 +452,107 @@ final class InMemoryDbColumnFamily<
                     valueInstance.wrap(valueViewBuffer, 0, valueViewBuffer.capacity());
 
                     final boolean shouldVisitNext = visitor.visit(keyInstance, valueInstance);
+
+                    if (!shouldVisitNext) {
+                      return;
+                    }
+                  }
+                }));
+  }
+
+  private void whileEqualPrefixKeyOnly(
+      final TransactionContext context,
+      final DbKey prefix,
+      final KeyType keyInstance,
+      final KeyVisitor<KeyType> visitor) {
+    whileEqualPrefixKeyOnly(context, prefix, prefix, keyInstance, visitor);
+  }
+
+  private void whileEqualPrefixKeyOnly(
+      final TransactionContext context,
+      final DbKey startAt,
+      final DbKey prefix,
+      final KeyType keyInstance,
+      final KeyVisitor<KeyType> visitor) {
+    final var seekTarget = Objects.requireNonNullElse(startAt, prefix);
+    Objects.requireNonNull(prefix);
+    Objects.requireNonNull(visitor);
+
+    iterationContext.withPrefixKey(
+        prefix,
+        prefixKey ->
+            ensureInOpenTransaction(
+                context,
+                state -> {
+                  final var seekTargetBuffer = iterationContext.keyWithColumnFamily(seekTarget);
+                  final byte[] seekTargetBytes = seekTargetBuffer.array();
+                  final Iterator<Map.Entry<Bytes, Bytes>> iterator =
+                      state.newIterator().seek(seekTargetBytes, seekTargetBytes.length).iterate();
+
+                  final byte[] prefixKeyBytes = prefixKey.toBytes();
+                  while (iterator.hasNext()) {
+                    final Map.Entry<Bytes, Bytes> entry = iterator.next();
+
+                    final byte[] keyBytes = entry.getKey().toBytes();
+                    if (!BufferUtil.startsWith(
+                        prefixKeyBytes, 0, prefixKeyBytes.length, keyBytes, 0, keyBytes.length)) {
+                      continue;
+                    }
+
+                    final DirectBuffer keyViewBuffer =
+                        FullyQualifiedKey.wrapKey(entry.getKey().toBytes());
+
+                    keyInstance.wrap(keyViewBuffer, 0, keyViewBuffer.capacity());
+
+                    final boolean shouldVisitNext = visitor.visit(keyInstance);
+
+                    if (!shouldVisitNext) {
+                      return;
+                    }
+                  }
+                }));
+  }
+
+  private void whileEqualPrefixReverseKeyOnly(
+      final TransactionContext context,
+      final DbKey startAt,
+      final DbKey prefix,
+      final KeyType keyInstance,
+      final KeyVisitor<KeyType> visitor) {
+    final var seekTarget = Objects.requireNonNullElse(startAt, prefix);
+    Objects.requireNonNull(prefix);
+    Objects.requireNonNull(visitor);
+
+    iterationContext.withPrefixKey(
+        prefix,
+        prefixKey ->
+            ensureInOpenTransaction(
+                context,
+                state -> {
+                  final var seekTargetBuffer = iterationContext.keyWithColumnFamily(seekTarget);
+                  final byte[] seekTargetBytes = seekTargetBuffer.array();
+                  final Iterator<Map.Entry<Bytes, Bytes>> iterator =
+                      state
+                          .newIterator()
+                          .seekReverse(seekTargetBytes, seekTargetBytes.length)
+                          .iterateReverse();
+
+                  final byte[] prefixKeyBytes = prefixKey.toBytes();
+                  while (iterator.hasNext()) {
+                    final Map.Entry<Bytes, Bytes> entry = iterator.next();
+
+                    final byte[] keyBytes = entry.getKey().toBytes();
+                    if (!BufferUtil.startsWith(
+                        prefixKeyBytes, 0, prefixKeyBytes.length, keyBytes, 0, keyBytes.length)) {
+                      continue;
+                    }
+
+                    final DirectBuffer keyViewBuffer =
+                        FullyQualifiedKey.wrapKey(entry.getKey().toBytes());
+
+                    keyInstance.wrap(keyViewBuffer, 0, keyViewBuffer.capacity());
+
+                    final boolean shouldVisitNext = visitor.visit(keyInstance);
 
                     if (!shouldVisitNext) {
                       return;


### PR DESCRIPTION
## Description

The upstream ColumnFamily interface added key-only iteration methods to avoid unnecessary value reads. This implements the new methods: forEachKey, whileTrue, whileEqualPrefix, and whileTrueReverse with KeyVisitor and Consumer overloads.

Upstream change that requires this fix https://github.com/camunda/camunda/pull/47690

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
