### PR TITLE
fix: create draft PRs for backport conflicts instead of failing

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -40,3 +40,10 @@ jobs:
             Backport of #${pull_number} to `${target_branch}`.
 
             relates to ${issue_refs}
+
+          add_author_as_assignee: true
+          add_author_as_reviewer: true
+          experimental: >
+            {
+              "conflict_resolution": "draft_commit_conflicts"
+            }


### PR DESCRIPTION
## Description

When a backport cherry-pick encounters merge conflicts, the `korthout/backport-action` previously used the default `conflict_resolution: fail` behavior — it would stop and only post a comment on the original PR with manual cherry-pick instructions, leaving no pull request open for the conflicting branches.

This change enables **`draft_commit_conflicts`** conflict resolution, which instructs the action to always open a **draft pull request** with the first conflict committed, along with instructions for resolving it locally. This makes conflicts visible and actionable directly in the PR list, rather than buried in comments.

Additionally, `add_author_as_assignee` and `add_author_as_reviewer` are enabled to match the setup used in `camunda/camunda`, ensuring the original author is notified and can act on the backport PR.

## Changes

- Set `experimental.conflict_resolution` to `draft_commit_conflicts` so conflicting backports open a draft PR instead of silently failing
- Set `add_author_as_assignee: true` to assign the original PR author to the backport PR
- Set `add_author_as_reviewer: true` to request a review from the original PR author on the backport PR

## Documentation

- [`conflict_resolution` option](https://github.com/korthout/backport-action?tab=readme-ov-file#conflict_resolution): `draft_commit_conflicts` — *"the backport will always create a draft pull request with the first conflict encountered committed. Instructions are provided on the original pull request on how to resolve the conflict and continue the cherry-pick."*
- [`add_author_as_assignee`](https://github.com/korthout/backport-action?tab=readme-ov-file#add_author_as_assignee): controls whether to set the author of the original PR as an assignee on the backport PR
- [`add_author_as_reviewer`](https://github.com/korthout/backport-action?tab=readme-ov-file#add_author_as_reviewer): controls whether to request a review from the author of the original PR on the backport PR

## Related

Observed when backporting #2113 — the action failed to create PRs for `stable/8.6`, `stable/8.7`, and `stable/8.8` due to cherry-pick conflicts, and only posted comments instead of opening draft PRs.
