### PR TITLE
deps: Update protobuf to 4.34.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <!-- Note: needs to be aligned with the version used by io.camunda:zeebe-client-java -->
     <version.grpc>1.79.0</version.grpc>
     <version.java>21</version.java>
-    <version.protobuf>4.33.5</version.protobuf>
+    <version.protobuf>4.34.0</version.protobuf>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Description

Upstream got updated, causing nightly 8.9 test to fail https://github.com/camunda/zeebe-process-test/actions/runs/23523909404/job/68472885712
