### PR TITLE
ci: ensure stable branch exists for minor

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -143,15 +143,21 @@ jobs:
         run: |
           git push origin "${RELEASE_VERSION}"
 
-      - name: Create new stable branch for minor
-        if: ${{ inputs.releaseType == 'minor' }}
-        run: |
-          git checkout -b "stable/${MINOR_VERSION}"
-
-      - name: Push new stable branch for minor
+      - name: Ensure stable branch exists for minor
         if: ${{ inputs.releaseType == 'minor' && inputs.dryRun == false }}
         run: |
-          git push origin "stable/${MINOR_VERSION}"
+          set -euo pipefail
+          MINOR_BRANCH="stable/${MINOR_VERSION}"
+
+          # If branch already exists on origin, do nothing (camunda/camunda-style)
+          if git ls-remote --exit-code --heads origin "${MINOR_BRANCH}" > /dev/null 2>&1; then
+            echo "Branch ${MINOR_BRANCH} already exists on origin; skipping creation."
+            exit 0
+          fi
+
+          # First minor for this line: create and push stable branch from main
+          git checkout -b "${MINOR_BRANCH}" "origin/main"
+          git push origin "${MINOR_BRANCH}"
 
       # Same logic as in camunda/camunda
       - name: Determine if pre-release

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -156,6 +156,7 @@ jobs:
           fi
 
           # First minor for this line: create and push stable branch from main
+          git fetch origin main
           git checkout -b "${MINOR_BRANCH}" "origin/main"
           git push origin "${MINOR_BRANCH}"
 


### PR DESCRIPTION
## Description

This pull request refines the release workflow to make the creation of stable branches for minor releases more robust. Instead of always attempting to create and push a new stable branch, the workflow now checks if the branch already exists on the remote and only creates it if necessary.

**Release workflow improvements:**

* Updated the `.github/workflows/create-release.yml` workflow so that, for minor releases, it checks if the `stable/${MINOR_VERSION}` branch already exists on the remote before attempting to create and push it. If the branch exists, it skips creation, preventing errors from duplicate branch creation.

## Related issues

Right now ZPT is not following the monorepo pattern because create-release.yml still tries to create stable/${MINOR_VERSION} every time, even if the branch already exists. For 8.9, stable/8.9 was pre-cut as described in [Issue #46249](https://github.com/camunda/camunda/issues/46249), so the job fails as soon as it hits:
`git push origin "stable/${MINOR_VERSION}"   # -> stable/8.9 already exists`
That’s why this started breaking “now”.
https://camunda.slack.com/archives/C06UWQNCU7M/p1774479436448319

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
