### PR TITLE
feat: Updated runner for GHA

### DIFF
--- a/.github/workflows/auto-merge-back-to-stable.yml
+++ b/.github/workflows/auto-merge-back-to-stable.yml
@@ -17,7 +17,7 @@ jobs:
     # Only run for PRs from release branches created by release automation
     if: startsWith(github.head_ref, 'release-') && github.actor == 'camundait'
     name: Auto-merge release to stable
-    runs-on: gcp-core-2-longrunning
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
       contents: write

--- a/.github/workflows/auto-merge-back-to-stable.yml
+++ b/.github/workflows/auto-merge-back-to-stable.yml
@@ -17,7 +17,7 @@ jobs:
     # Only run for PRs from release branches created by release automation
     if: startsWith(github.head_ref, 'release-') && github.actor == 'camundait'
     name: Auto-merge release to stable
-    runs-on: ubuntu-slim
+    runs-on: gcp-core-2-longrunning
     timeout-minutes: 90
     permissions:
       contents: write


### PR DESCRIPTION
## Description

The currently used runner for the [Auto-merge release to stable](https://github.com/camunda/zeebe-process-test/actions/workflows/auto-merge-back-to-stable.yml) workflow is `ubtuntu-slim` which has a hard limit of [15 minutes TTL](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#usage-limits). As the workflow is running for a much longer time (90 minutes max), the runner have to be updated for a more stable long running runner.

[Sample cancelled workflow](https://github.com/camunda/zeebe-process-test/actions/runs/23800708124/job/69360035350)