### PR TITLE
fix: pin community-action-maven-release to v2.0.3

### DIFF
--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Build and deploy to Maven
         if: ${{ env.DRY_RUN == 'false' }}
         id: release
-        uses: camunda-community-hub/community-action-maven-release@v2
+        uses: camunda-community-hub/community-action-maven-release@b7c917128dfc701a9fae1b294ebbf97c5b4420c3 # v2.0.3
         with:
           release-version: ${{ inputs.releaseVersion || github.event.release.tag_name }}
           release-profile: community-action-maven-release


### PR DESCRIPTION
## Problem

The deploy-artifact workflow was failing with **401 Unauthorized** when resolving dependencies from Camunda's private Nexus repository (e.g. `zeebe-protocol-jackson`).

### Root cause

The `community-action-maven-release` action overwrites `~/.m2/settings.xml` during initialization. The old settings.xml:
1. Only defined a `camunda-nexus` server entry, but the pom's `<repositories>` uses `camunda-nexus-release` — no matching credentials for downloads
2. Did not set `NEXUS_USR`/`NEXUS_PSW` env vars on the build step — credentials resolved to empty strings

## Fix

Pinned the action to **v2.0.3** (`b7c9171`), which includes [camunda-community-hub/community-action-maven-release#80](https://github.com/camunda-community-hub/community-action-maven-release/pull/80):
- Adds `camunda-nexus-release` server entry to settings.xml
- Sets `NEXUS_USR`/`NEXUS_PSW` env vars on the "Run maven" step

Also pins to commit SHA for security best practices.