### PR TITLE
[Backport stable/8.7] fix: pin community-action-maven-release to v2.0.3

### DIFF
--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Build and deploy to Maven
         if: ${{ env.DRY_RUN == 'false' }}
         id: release
-        uses: camunda-community-hub/community-action-maven-release@v2
+        uses: camunda-community-hub/community-action-maven-release@b7c917128dfc701a9fae1b294ebbf97c5b4420c3 # v2.0.3
         with:
           release-version: ${{ inputs.releaseVersion || github.event.release.tag_name }}
           release-profile: community-action-maven-release


### PR DESCRIPTION
# Description
Backport of #2186 to `stable/8.7`.

relates to 