### PR TITLE
fix: add always() condition to Import Secrets step in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-back-to-stable.yml
+++ b/.github/workflows/auto-merge-back-to-stable.yml
@@ -242,6 +242,7 @@ jobs:
           repository-name: ${{ github.event.repository.name }}
       
       - name: Import Secrets
+        if: always() && env.DRY_RUN != 'true'
         id: secrets
         uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         with:


### PR DESCRIPTION
## Description

The `Import Secrets` step in the auto-merge workflow was missing `if: always() && env.DRY_RUN != 'true'`. When a prior step (e.g. `Wait for required checks`) fails, this caused the Import Secrets step to be skipped (default `if: success()`), so the `Report auto-merge result` step ran with an empty `clientConfig` and the notification to the release process was silently lost.

Same fix as camunda/camunda#51212.

## Fix

Add `if: always() && env.DRY_RUN != 'true'` to the Import Secrets step, matching the condition already on the Report step.