### PR TITLE
[Backport stable/8.7] fix: add always() condition to Import Secrets step in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-back-to-stable.yml
+++ b/.github/workflows/auto-merge-back-to-stable.yml
@@ -242,6 +242,7 @@ jobs:
           repository-name: ${{ github.event.repository.name }}
       
       - name: Import Secrets
+        if: always() && env.DRY_RUN != 'true'
         id: secrets
         uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         with:


### PR DESCRIPTION
# Description
Backport of #2191 to `stable/8.7`.

relates to 