### PR TITLE
fix: report repository to release process

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -214,7 +214,8 @@ jobs:
           variables: |
             {
               "is_zpt_release_successful": "${{ needs.create-release.result == 'success' }}",
-              "zpt_workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "zpt_workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "zpt_repository": "${{ github.repository }}"
             }
 
       - name: Send failure Slack notification

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -208,7 +208,8 @@ jobs:
           variables: |
             {
               "is_deploy_artifact_successful": "${{ needs.deploy.result == 'success' }}",
-              "zpt_workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "zpt_workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "zpt_repository": "${{ github.repository }}"
             }
 
       - name: Send success Slack notification


### PR DESCRIPTION
## Description

Our C8 process expects a key `zpt_repository` in the notification message, that will later on be displayed in a user task. Without that information the MRM cannot tell easily whether this is about monorepo or ZPT:

Instance: https://bru-2.operate.camunda.io/a5d45cd5-3aad-48a4-9fe1-2d25d8e0b5a6/operate/processes/2251799878311169

<img width="984" height="402" alt="image" src="https://github.com/user-attachments/assets/211a11d8-dbc7-4f6e-91ba-f650d9778211" />

<img width="605" height="467" alt="image" src="https://github.com/user-attachments/assets/56a05058-f7ab-42de-9ad6-9e66104bff66" />


## Related issues

None


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
