### PR TITLE
[Backport main] Add missing Maven POM metadata fields for OSS publish

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -25,6 +25,7 @@
   <artifactId>zeebe-process-test-examples</artifactId>
 
   <name>Zeebe Process Test Examples</name>
+  <description>Example process tests demonstrating usage of Zeebe Process Test.</description>
 
   <properties>
     <maven.compiler.source>21</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
   <name>Zeebe Process Test Root</name>
   <description>This pom should be the parent of all specified modules. It defines all versions and provides
     plugins that are required for the child modules.</description>
+  <url>https://github.com/camunda/zeebe-process-test</url>
   <inceptionYear>2021</inceptionYear>
 
   <licenses>
@@ -39,6 +40,14 @@
       <url>http://www.apache.org/licenses/LICENSE-2.0</url>
     </license>
   </licenses>
+
+  <developers>
+    <developer>
+      <name>Camunda Services GmbH</name>
+      <organization>Camunda Services GmbH</organization>
+      <organizationUrl>https://camunda.com</organizationUrl>
+    </developer>
+  </developers>
 
   <modules>
     <module>api</module>

--- a/qa/abstracts/pom.xml
+++ b/qa/abstracts/pom.xml
@@ -12,6 +12,7 @@
   <packaging>jar</packaging>
 
   <name>Zeebe Process Test QA Abstracts</name>
+  <description>Abstract QA test cases shared between embedded and testcontainer test modules.</description>
 
   <properties>
     <version.java>8</version.java>

--- a/qa/embedded/pom.xml
+++ b/qa/embedded/pom.xml
@@ -25,6 +25,7 @@
   <artifactId>zeebe-process-test-qa-embedded</artifactId>
 
   <name>Zeebe Process Test QA Embedded</name>
+  <description>QA tests for the embedded Zeebe Process Test engine.</description>
 
   <properties>
     <version.java>21</version.java>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -15,12 +15,35 @@
   <name>Zeebe Process Test QA</name>
 
   <description>QA tests for testing the Zeebe Process Test project.</description>
+  <url>https://github.com/camunda/zeebe-process-test</url>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Camunda Services GmbH</name>
+      <organization>Camunda Services GmbH</organization>
+      <organizationUrl>https://camunda.com</organizationUrl>
+    </developer>
+  </developers>
 
   <modules>
     <module>abstracts</module>
     <module>embedded</module>
     <module>testcontainers</module>
   </modules>
+
+  <scm>
+    <connection>scm:git:git@github.com:camunda/zeebe-process-test.git</connection>
+    <developerConnection>scm:git:git@github.com:camunda/zeebe-process-test.git</developerConnection>
+    <tag>HEAD</tag>
+    <url>https://github.com/camunda/zeebe-process-test</url>
+  </scm>
 
   <dependencyManagement>
     <dependencies>

--- a/qa/testcontainers/pom.xml
+++ b/qa/testcontainers/pom.xml
@@ -10,6 +10,7 @@
   <artifactId>zeebe-process-test-qa-testcontainers</artifactId>
 
   <name>Zeebe Process Test QA Testcontainers</name>
+  <description>QA tests for Zeebe Process Test using Testcontainers.</description>
 
   <properties>
     <!-- needed as newer model releases don't support jdk 8 -->

--- a/spring-test/common/pom.xml
+++ b/spring-test/common/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>spring-boot-starter-camunda-test-common</artifactId>
   <name>Spring Boot Starter Camunda Test commons</name>
+  <description>Common components shared between embedded and testcontainer Spring Boot test starters.</description>
 
   <dependencies>
     <dependency>

--- a/spring-test/embedded/pom.xml
+++ b/spring-test/embedded/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>spring-boot-starter-camunda-test</artifactId>
   <name>Spring Boot Starter Camunda Test Embedded</name>
+  <description>Spring Boot starter for testing Camunda processes using an embedded engine.</description>
 
   <dependencies>
     <dependency>

--- a/spring-test/pom.xml
+++ b/spring-test/pom.xml
@@ -13,12 +13,36 @@
   <packaging>pom</packaging>
 
   <name>Spring Boot Starter Camunda Test POM</name>
+  <description>Spring Boot starter for testing Camunda Platform 8 BPMN processes</description>
+  <url>https://github.com/camunda/zeebe-process-test</url>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Camunda Services GmbH</name>
+      <organization>Camunda Services GmbH</organization>
+      <organizationUrl>https://camunda.com</organizationUrl>
+    </developer>
+  </developers>
 
   <modules>
     <module>common</module>
     <module>embedded</module>
     <module>testcontainer</module>
   </modules>
+
+  <scm>
+    <connection>scm:git:git@github.com:camunda/zeebe-process-test.git</connection>
+    <developerConnection>scm:git:git@github.com:camunda/zeebe-process-test.git</developerConnection>
+    <tag>HEAD</tag>
+    <url>https://github.com/camunda/zeebe-process-test</url>
+  </scm>
 
   <properties>
     <plugin.version.license>5.0.0</plugin.version.license>

--- a/spring-test/testcontainer/pom.xml
+++ b/spring-test/testcontainer/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>spring-boot-starter-camunda-test-testcontainer</artifactId>
   <name>Spring Boot Starter Camunda Test Testcontainer</name>
+  <description>Spring Boot starter for testing Camunda processes using Testcontainers.</description>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
# Description
Backport of #2203 to `main`.

relates to #2201