### PR TITLE
fix: use flatten bom mode for pom-packaged modules

### DIFF
--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -15,35 +15,12 @@
   <name>Zeebe Process Test QA</name>
 
   <description>QA tests for testing the Zeebe Process Test project.</description>
-  <url>https://github.com/camunda/zeebe-process-test</url>
-
-  <licenses>
-    <license>
-      <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-    </license>
-  </licenses>
-
-  <developers>
-    <developer>
-      <name>Camunda Services GmbH</name>
-      <organization>Camunda Services GmbH</organization>
-      <organizationUrl>https://camunda.com</organizationUrl>
-    </developer>
-  </developers>
 
   <modules>
     <module>abstracts</module>
     <module>embedded</module>
     <module>testcontainers</module>
   </modules>
-
-  <scm>
-    <connection>scm:git:git@github.com:camunda/zeebe-process-test.git</connection>
-    <developerConnection>scm:git:git@github.com:camunda/zeebe-process-test.git</developerConnection>
-    <tag>HEAD</tag>
-    <url>https://github.com/camunda/zeebe-process-test</url>
-  </scm>
 
   <dependencyManagement>
     <dependencies>
@@ -66,6 +43,16 @@
             <!-- used in tests to provide an slf4j implementation-->
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-simple</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+      <!-- Use bom flatten mode for pom packaging so the published .pom inlines
+           inherited metadata (groupId, version, licenses, scm, developers, url)
+           required by the Sonatype Central Portal validator. -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <configuration>
+          <flattenMode>bom</flattenMode>
         </configuration>
       </plugin>
     </plugins>

--- a/spring-test/pom.xml
+++ b/spring-test/pom.xml
@@ -14,35 +14,12 @@
 
   <name>Spring Boot Starter Camunda Test POM</name>
   <description>Spring Boot starter for testing Camunda Platform 8 BPMN processes</description>
-  <url>https://github.com/camunda/zeebe-process-test</url>
-
-  <licenses>
-    <license>
-      <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-    </license>
-  </licenses>
-
-  <developers>
-    <developer>
-      <name>Camunda Services GmbH</name>
-      <organization>Camunda Services GmbH</organization>
-      <organizationUrl>https://camunda.com</organizationUrl>
-    </developer>
-  </developers>
 
   <modules>
     <module>common</module>
     <module>embedded</module>
     <module>testcontainer</module>
   </modules>
-
-  <scm>
-    <connection>scm:git:git@github.com:camunda/zeebe-process-test.git</connection>
-    <developerConnection>scm:git:git@github.com:camunda/zeebe-process-test.git</developerConnection>
-    <tag>HEAD</tag>
-    <url>https://github.com/camunda/zeebe-process-test</url>
-  </scm>
 
   <properties>
     <plugin.version.license>5.0.0</plugin.version.license>
@@ -60,6 +37,16 @@
             <!-- used in tests to provide an slf4j implementation-->
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-simple</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+      <!-- Use bom flatten mode for pom packaging so the published .pom inlines
+           inherited metadata (groupId, version, licenses, scm, developers, url)
+           required by the Sonatype Central Portal validator. -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <configuration>
+          <flattenMode>bom</flattenMode>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
## Summary

Fixes the remaining Central Portal publish failures on `stable/8.8` after #2203 — specifically:

```
Failed to get coordinates from pom file io/camunda/spring-boot-starter-camunda-test-pom/8.8.23/…
Failed to get coordinates from pom file io/camunda/zeebe-process-test-qa/8.8.23/…
```

closes #2201

### Root cause

The Sonatype Central Portal validator reads each uploaded `.pom` file literally and does not resolve parent inheritance. Our two pom-packaged aggregator modules (`zeebe-process-test-qa`, `spring-boot-starter-camunda-test-pom`) declare only `<artifactId>` and inherit `<groupId>`, `<version>`, `<licenses>`, `<scm>`, `<developers>`, `<url>` from the root pom.

The `flatten-maven-plugin` configured in the root uses `<flattenMode>ossrh</flattenMode>`, which deliberately does **not** replace the project pom file for `packaging=pom` — you can see this in the build logs: `Project POM file not updated to point to the flattened POM due to 'pom' packaging`. So the raw source pom is what gets uploaded, and it is missing the fields the validator requires.

### Fix

Override the flatten mode to `bom` on both pom-packaged modules. Unlike `ossrh`, `bom` mode updates the pom file even for pom packaging and inlines the inherited metadata. This is the same pattern camunda/camunda uses for its published BOMs (see `bom/pom.xml` at https://github.com/camunda/camunda/blob/main/bom/pom.xml).

With that in place, the explicit `<url>`/`<licenses>`/`<scm>`/`<developers>` copies previously added to these modules in #2203 become redundant — inheritance resolves them automatically — so they are removed.

Verified locally by running `mvn flatten:flatten` in each module and confirming the generated `.flattened-pom.xml` contains groupId, version, packaging, name, description, url, licenses, developers, and scm.

## Test plan

- [x] Check CI passes on this PR
- [ ] Trigger a release (or dry-run) and confirm the Central Portal validator no longer reports `Failed to get coordinates` or missing metadata for the two pom-packaged modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)