### PR TITLE
[Backport stable/8.9] fix: use flatten bom mode for pom-packaged modules

### DIFF
--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -15,35 +15,12 @@
   <name>Zeebe Process Test QA</name>
 
   <description>QA tests for testing the Zeebe Process Test project.</description>
-  <url>https://github.com/camunda/zeebe-process-test</url>
-
-  <licenses>
-    <license>
-      <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-    </license>
-  </licenses>
-
-  <developers>
-    <developer>
-      <name>Camunda Services GmbH</name>
-      <organization>Camunda Services GmbH</organization>
-      <organizationUrl>https://camunda.com</organizationUrl>
-    </developer>
-  </developers>
 
   <modules>
     <module>abstracts</module>
     <module>embedded</module>
     <module>testcontainers</module>
   </modules>
-
-  <scm>
-    <connection>scm:git:git@github.com:camunda/zeebe-process-test.git</connection>
-    <developerConnection>scm:git:git@github.com:camunda/zeebe-process-test.git</developerConnection>
-    <tag>HEAD</tag>
-    <url>https://github.com/camunda/zeebe-process-test</url>
-  </scm>
 
   <dependencyManagement>
     <dependencies>
@@ -66,6 +43,16 @@
             <!-- used in tests to provide an slf4j implementation-->
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-simple</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+      <!-- Use bom flatten mode for pom packaging so the published .pom inlines
+           inherited metadata (groupId, version, licenses, scm, developers, url)
+           required by the Sonatype Central Portal validator. -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <configuration>
+          <flattenMode>bom</flattenMode>
         </configuration>
       </plugin>
     </plugins>

--- a/spring-test/pom.xml
+++ b/spring-test/pom.xml
@@ -14,35 +14,12 @@
 
   <name>Spring Boot Starter Camunda Test POM</name>
   <description>Spring Boot starter for testing Camunda Platform 8 BPMN processes</description>
-  <url>https://github.com/camunda/zeebe-process-test</url>
-
-  <licenses>
-    <license>
-      <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-    </license>
-  </licenses>
-
-  <developers>
-    <developer>
-      <name>Camunda Services GmbH</name>
-      <organization>Camunda Services GmbH</organization>
-      <organizationUrl>https://camunda.com</organizationUrl>
-    </developer>
-  </developers>
 
   <modules>
     <module>common</module>
     <module>embedded</module>
     <module>testcontainer</module>
   </modules>
-
-  <scm>
-    <connection>scm:git:git@github.com:camunda/zeebe-process-test.git</connection>
-    <developerConnection>scm:git:git@github.com:camunda/zeebe-process-test.git</developerConnection>
-    <tag>HEAD</tag>
-    <url>https://github.com/camunda/zeebe-process-test</url>
-  </scm>
 
   <properties>
     <plugin.version.license>5.0.0</plugin.version.license>
@@ -60,6 +37,16 @@
             <!-- used in tests to provide an slf4j implementation-->
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-simple</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+      <!-- Use bom flatten mode for pom packaging so the published .pom inlines
+           inherited metadata (groupId, version, licenses, scm, developers, url)
+           required by the Sonatype Central Portal validator. -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <configuration>
+          <flattenMode>bom</flattenMode>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
# Description
Backport of #2209 to `stable/8.9`.

relates to #2203 #2201 #2203