### PR TITLE
build: Ignore AssertJ annotation changes

### DIFF
--- a/assertions/ignored-changes.json
+++ b/assertions/ignored-changes.json
@@ -10,6 +10,30 @@
           "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
           "classQualifiedName": "io.camunda.zeebe.process.test.assertions.*",
           "justification": "Inherited from extended assertj class."
+        },
+        {
+          "ignore": true,
+          "regex": true,
+          "code": "java.annotation.removed",
+          "classQualifiedName": "io.camunda.zeebe.process.test.assertions.*",
+          "annotation": "@org.assertj.core.util.CheckReturnValue",
+          "justification": "AssertJ moved CheckReturnValue annotation packages; fluent API behavior is unchanged."
+        },
+        {
+          "ignore": true,
+          "regex": true,
+          "code": "java.annotation.added",
+          "classQualifiedName": "io.camunda.zeebe.process.test.assertions.*",
+          "annotation": "@org.assertj.core.annotation.CheckReturnValue",
+          "justification": "AssertJ moved CheckReturnValue annotation packages; fluent API behavior is unchanged."
+        },
+        {
+          "ignore": true,
+          "regex": true,
+          "code": "java.annotation.added",
+          "classQualifiedName": "io.camunda.zeebe.process.test.assertions.*",
+          "annotation": "@org.assertj.core.internal.annotation.Contract(.*)",
+          "justification": "AssertJ added a new annotation to the abstract base class; fluent API behavior is unchanged."
         }
       ]
     }

--- a/spring-test/embedded/src/test/java/io/camunda/zeebe/spring/client/jobhandling/JobHandlerTest.java
+++ b/spring-test/embedded/src/test/java/io/camunda/zeebe/spring/client/jobhandling/JobHandlerTest.java
@@ -367,7 +367,6 @@ public class JobHandlerTest {
 
   @SpringBootTest(
       classes = {
-        DefaultWorkerTest.class,
         DefaultWorkerTest.WorkersConfig.class,
         JobHandlerTest.TestMetricsConfiguration.class
       },


### PR DESCRIPTION
## Description

The new version of AssertJ changes some annotations. Ignore these changes as they have no impact on ZPT.

## Related issues

Fixes the following Revapi errors:

```
Error:  java.annotation.added: method SELF org.assertj.core.api.AbstractAssert<SELF extends org.assertj.core.api.AbstractAssert<SELF, ACTUAL>, ACTUAL>::usingEquals(java.util.function.BiPredicate<? super ACTUAL, ? super ACTUAL>, java.lang.String) @ io.camunda.zeebe.process.test.assertions.VariablesMapAssert: Element newly annotated with 'org.assertj.core.annotation.CheckReturnValue'. https://revapi.org/revapi-java/differences.html#java.annotation.added
Error:  java.annotation.removed: method SELF org.assertj.core.api.AbstractAssert<SELF extends org.assertj.core.api.AbstractAssert<SELF, ACTUAL>, ACTUAL>::usingEquals(java.util.function.BiPredicate<? super ACTUAL, ? super ACTUAL>, java.lang.String) @ io.camunda.zeebe.process.test.assertions.VariablesMapAssert: Element no longer annotated with 'org.assertj.core.util.CheckReturnValue'. https://revapi.org/revapi-java/differences.html#java.annotation.removed
```

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
