### PR TITLE
feat: extract Maven Central deployment ID and forward to C8 cluster

### DIFF
--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -29,6 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     if: ${{ always() && (needs.test.result == 'success' || needs.test.result == 'skipped') }}
+    permissions:
+      contents: write
+      actions: read
 
     outputs:
       deploymentId: ${{ steps.extract-deployment-id.outputs.deploymentId }}
@@ -182,7 +185,7 @@ jobs:
 
       - name: Extract Maven Central deployment ID
         id: extract-deployment-id
-        if: always() && steps.release.conclusion != 'skipped'
+        if: always()
         # Never block the release on extraction failure — the deployment ID is
         # for downstream automation only; manual recovery is always possible.
         continue-on-error: true
@@ -198,7 +201,7 @@ jobs:
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             "${api}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs?per_page=100" \
-            | jq -r ".jobs[] | select(.runner_name == \"$RUNNER_NAME\") | .id")
+            | jq -r ".jobs[] | select(.name == \"deploy\") | .id")
 
           deployment_id=$(curl -fsSL \
             -H "Authorization: Bearer ${GH_TOKEN}" \

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -30,6 +30,9 @@ jobs:
     needs: [test]
     if: ${{ always() && (needs.test.result == 'success' || needs.test.result == 'skipped') }}
 
+    outputs:
+      deploymentId: ${{ steps.extract-deployment-id.outputs.deploymentId }}
+
     env:
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' }}
       OWNER: "camunda"
@@ -177,6 +180,45 @@ jobs:
           asset_name: ${{ steps.release.outputs.artifacts_archive_path }}
           asset_content_type: application/zip
 
+      - name: Extract Maven Central deployment ID
+        id: extract-deployment-id
+        if: always() && steps.release.conclusion != 'skipped'
+        # Never block the release on extraction failure — the deployment ID is
+        # for downstream automation only; manual recovery is always possible.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The central-publishing-maven-plugin only emits the deployment ID via a log line:
+          #   "Uploaded bundle successfully, deployment name: ..., deploymentId: <uuid>..."
+          # It is not persisted to disk by the plugin. So we fetch this job's log from the GHA API after the maven step has run and grep it.
+          api="https://api.github.com/repos/${{ github.repository }}"
+
+          job_id=$(curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "${api}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs?per_page=100" \
+            | jq -r ".jobs[] | select(.runner_name == \"$RUNNER_NAME\") | .id")
+
+          deployment_id=$(curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "${api}/actions/jobs/${job_id}/logs" \
+            | grep -oE 'deploymentId: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' \
+            | tail -1 \
+            | awk '{print $2}' || true)
+
+          if [[ -n "${deployment_id}" ]]; then
+            echo "deploymentId=${deployment_id}" >> "$GITHUB_OUTPUT"
+            echo "::notice::Maven Central deployment ID: ${deployment_id}"
+          elif [[ "${{ env.DRY_RUN }}" == "true" ]]; then
+            echo "deploymentId=dry-run-${{ inputs.releaseVersion }}" >> "$GITHUB_OUTPUT"
+            echo "\u2139\ufe0f Dry run \u2014 emitting placeholder deployment ID"
+          else
+            echo "deploymentId=not-found" >> "$GITHUB_OUTPUT"
+            echo "\u2139\ufe0f No Maven Central deployment ID found in build output" >&2
+          fi
+
   notify-release:
     name: Send notifications
     runs-on: ubuntu-latest
@@ -209,7 +251,8 @@ jobs:
             {
               "is_deploy_artifact_successful": "${{ needs.deploy.result == 'success' }}",
               "zpt_workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-              "zpt_repository": "${{ github.repository }}"
+              "zpt_repository": "${{ github.repository }}",
+              "zpt_maven_central_deployment_id": "${{ needs.deploy.outputs.deploymentId }}"
             }
 
       - name: Send success Slack notification


### PR DESCRIPTION
## Description

Extracts the Maven Central deployment ID emitted by the `central-publishing-maven-plugin` during deploy and exposes it as a job output, so the C8 release orchestration process can reference it for downstream automation (e.g., publishing/dropping the deployment via the Sonatype Central Portal Publisher API).

Mirrors the logic from https://github.com/camunda/camunda/pull/52221 adapted for ZPT.

## Changes

- Added `deploymentId` as an output of the `deploy` job
- After the release step, fetches the job's own logs from the GHA API and greps for the `deploymentId: <uuid>` pattern emitted by the central-publishing-maven-plugin
- Falls back to `dry-run-<version>` for dry runs and `not-found` if extraction fails
- Uses `continue-on-error: true` to never block the release on extraction failure
- Forwards the extracted deployment ID to the C8 cluster via the existing `Report deploy result to C8` step as `zpt_maven_central_deployment_id`