### PR TITLE
fix: actually test (and pass) Spring Boot 4 in CI on stable/8.8

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -71,7 +71,10 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         # Note: `3.5` is an invalid profile just serving as a placeholder for the default version.
-        spring-boot-version: [ 3.5, 4.0]
+        # Values MUST be quoted: unquoted `4.0` is parsed as a YAML float and rendered as `4`,
+        # so `spring-boot-${{ matrix.spring-boot-version }}` would resolve to the non-existent
+        # `spring-boot-4` profile instead of `spring-boot-4.0` (silently testing the default version).
+        spring-boot-version: [ '3.5', '4.0' ]
 
     steps:
       - name: Checkout
@@ -129,7 +132,9 @@ jobs:
       max-parallel: 3
       matrix:
         # Note: `default` is an invalid profile just serving as a placeholder with no effect.
-        spring-boot-version: [ default, 4.0 ]
+        # Quote version values: unquoted `4.0` is parsed as a YAML float and rendered as `4`,
+        # which would resolve to the non-existent `spring-boot-4` profile instead of `spring-boot-4.0`.
+        spring-boot-version: [ default, '4.0' ]
     env:
       IMAGE_NAME: "qa-tests"
 

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,14 @@
         <version>${dependency.zeebe.version}</version>
       </dependency>
 
+      <!-- Spring Boot 4 variant of the Camunda Spring SDK starter, selected via the
+           spring-boot-4.0 profile (see spring-test modules). -->
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-spring-boot-4-starter</artifactId>
+        <version>${dependency.zeebe.version}</version>
+      </dependency>
+
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>camunda-client-java</artifactId>

--- a/spring-test/common/pom.xml
+++ b/spring-test/common/pom.xml
@@ -41,7 +41,7 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>camunda-spring-boot-starter</artifactId>
+      <artifactId>${camunda.spring-boot.starter.artifactId}</artifactId>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>

--- a/spring-test/embedded/pom.xml
+++ b/spring-test/embedded/pom.xml
@@ -46,7 +46,7 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>camunda-spring-boot-starter</artifactId>
+      <artifactId>${camunda.spring-boot.starter.artifactId}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/spring-test/pom.xml
+++ b/spring-test/pom.xml
@@ -22,6 +22,9 @@
   </modules>
 
   <properties>
+    <!-- Camunda Spring SDK starter artifact; swapped to the Spring Boot 4 variant
+         by the spring-boot-4.0 profile below. -->
+    <camunda.spring-boot.starter.artifactId>camunda-spring-boot-starter</camunda.spring-boot.starter.artifactId>
     <plugin.version.license>5.0.0</plugin.version.license>
     <version.java>17</version.java>
   </properties>
@@ -84,6 +87,14 @@
     <profile>
       <id>spring-boot-4.0</id>
       <properties>
+        <!-- The default camunda-spring-boot-starter targets Spring Boot 3; the SDK ships
+             a dedicated Spring Boot 4 starter that must be used under Spring Boot 4. -->
+        <camunda.spring-boot.starter.artifactId>camunda-spring-boot-4-starter</camunda.spring-boot.starter.artifactId>
+        <!-- Spring Boot 4 / Spring Framework 7 require JUnit 6. The root pom imports
+             junit-bom before spring-boot-dependencies, so its version wins; align it
+             with the JUnit version managed by spring-boot-dependencies 4.0.1 (6.0.1)
+             to avoid NoSuchMethodError from SpringExtension against JUnit 5 APIs. -->
+        <dependency.junit.version>6.0.1</dependency.junit.version>
         <dependency.spring-boot.version>4.0.1</dependency.spring-boot.version>
       </properties>
     </profile>

--- a/spring-test/testcontainer/pom.xml
+++ b/spring-test/testcontainer/pom.xml
@@ -32,7 +32,7 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>camunda-spring-boot-starter</artifactId>
+      <artifactId>${camunda.spring-boot.starter.artifactId}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Description

Fixes #2306 and makes the Spring Boot 4 CI matrix on `stable/8.8` **actually test against — and pass on — Spring Boot 4**.

### 1. The original bug (silent no-op)
The matrix value `4.0` was unquoted, so YAML parsed it as a float rendered as `4`. The Maven invocation expanded to `-P !localBuild,spring-boot-4`, but the profile is `spring-boot-4.0`, so it never activated (`[WARNING] ... could not be activated`) and the build silently fell back to the default Spring Boot 3.5.14. **Spring Boot 4 was never tested.** Fixed by quoting the matrix values (both matrices).

### 2. What quoting exposed — two real SB4 incompatibilities
Once the profile actually activated, the SB4 jobs failed, revealing genuine (previously-masked) issues:

- **JUnit version.** The root pom imports `junit-bom` (5.13.4) *before* `spring-boot-dependencies`, so its version wins. Spring Boot 4 / Spring Framework 7 require **JUnit 6** — `SpringExtension` calls `ExtensionContext.Store.computeIfAbsent(...)`, absent in JUnit 5 → `NoSuchMethodError`. Fixed by aligning `dependency.junit.version` with the version `spring-boot-dependencies:4.0.1` manages (**6.0.1**), scoped to the profile.

- **Camunda Spring SDK starter.** `camunda-spring-boot-starter` targets Spring Boot 3; under SB4 its `CamundaActuatorConfiguration.micrometerMetricsRecorder` fails with `@ConditionalOnMissingBean ... BeanTypeDeductionException`. The SDK ships a dedicated **`camunda-spring-boot-4-starter`** (published for 8.8.x). Selected via a `camunda.spring-boot.starter.artifactId` property that the `spring-boot-4.0` profile overrides; the default build is unchanged.

## Verification (local, `-P spring-boot-4.0`)
- Embedded module test suite **passes**, including the previously-failing `JobWorkerAnnotationOnTestClassTest` and `ZeebeClientDisabledInCamundaSpringTest`.
- Dependency resolution confirmed: SB4 profile → `camunda-spring-boot-4-starter` + JUnit 6.0.1 (no duplicate starters); default build → `camunda-spring-boot-starter` + JUnit 5.13.4.
- The testcontainers SB4 job needs Docker and is verified by CI here.

## Companion docs PR
User-facing guidance for consuming `spring-boot-starter-camunda-test` under Spring Boot 4 (exclude the SB3 starter, add `camunda-spring-boot-4-starter`): **camunda/camunda-docs#9040** (covers 8.8 and 8.7).

## Scope
Only `stable/8.8` was affected by the original bug. `main`/`stable/8.9` already default to Spring Boot 4.0.6 (their 8.9.x SDK is SB4-native, so they use the regular starter); `stable/8.7`/`stable/8.6` use `3.5` which YAML preserves correctly. See the [branch assessment on #2306](https://github.com/camunda/zeebe-process-test/issues/2306#issuecomment-4660121170).

Closes #2306

🤖 Generated with [Claude Code](https://claude.com/claude-code)
