### PR TITLE
ci: add Spring Boot 4 test coverage on stable/8.7

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -71,7 +71,10 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         # Note: `default` is an invalid profile just serving as a placeholder with no effect.
-        spring-boot-version: [ default, 3.5]
+        # Values MUST be quoted: unquoted `4.0` is parsed as a YAML float and rendered as `4`,
+        # so `spring-boot-${{ matrix.spring-boot-version }}` would resolve to the non-existent
+        # `spring-boot-4` profile instead of `spring-boot-4.0` (silently testing the default version).
+        spring-boot-version: [ default, '3.5', '4.0' ]
 
     steps:
       - name: Checkout
@@ -129,7 +132,9 @@ jobs:
       max-parallel: 3
       matrix:
         # Note: `default` is an invalid profile just serving as a placeholder with no effect.
-        spring-boot-version: [ default, 3.5 ]
+        # Quote version values: unquoted `4.0` is parsed as a YAML float and rendered as `4`,
+        # which would resolve to the non-existent `spring-boot-4` profile instead of `spring-boot-4.0`.
+        spring-boot-version: [ default, '3.5', '4.0' ]
     env:
       IMAGE_NAME: "qa-tests"
 

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,14 @@
         <version>${dependency.zeebe.version}</version>
       </dependency>
 
+      <!-- Spring Boot 4 variant of the Camunda Spring SDK starter, selected via the
+           spring-boot-4.0 profile (see spring-test modules). -->
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-spring-boot-4-starter</artifactId>
+        <version>${dependency.zeebe.version}</version>
+      </dependency>
+
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-client-java</artifactId>

--- a/spring-test/common/pom.xml
+++ b/spring-test/common/pom.xml
@@ -37,7 +37,7 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>spring-boot-starter-camunda-sdk</artifactId>
+      <artifactId>${camunda.spring-boot.starter.artifactId}</artifactId>
     </dependency>
 
     <dependency>

--- a/spring-test/embedded/pom.xml
+++ b/spring-test/embedded/pom.xml
@@ -46,7 +46,7 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>spring-boot-starter-camunda-sdk</artifactId>
+      <artifactId>${camunda.spring-boot.starter.artifactId}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/spring-test/pom.xml
+++ b/spring-test/pom.xml
@@ -103,6 +103,18 @@
         <dependency.junit.version>6.0.1</dependency.junit.version>
         <dependency.spring-boot.version>4.0.1</dependency.spring-boot.version>
       </properties>
+      <dependencyManagement>
+        <dependencies>
+          <!-- camunda-spring-boot-4-starter brings guava (which pulls failureaccess 1.0.2)
+               alongside failureaccess 1.0.3 directly; pin to 1.0.3 so the enforcer
+               dependencyConvergence rule passes. -->
+          <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>failureaccess</artifactId>
+            <version>1.0.3</version>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
     </profile>
   </profiles>
 </project>

--- a/spring-test/pom.xml
+++ b/spring-test/pom.xml
@@ -22,6 +22,9 @@
   </modules>
 
   <properties>
+    <!-- Camunda Spring SDK starter artifact; swapped to the Spring Boot 4 variant
+         by the spring-boot-4.0 profile below. -->
+    <camunda.spring-boot.starter.artifactId>spring-boot-starter-camunda-sdk</camunda.spring-boot.starter.artifactId>
     <plugin.version.license>4.6</plugin.version.license>
     <version.java>17</version.java>
   </properties>
@@ -85,6 +88,20 @@
       <id>spring-boot-3.5</id>
       <properties>
         <dependency.spring-boot.version>3.5.7</dependency.spring-boot.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>spring-boot-4.0</id>
+      <properties>
+        <!-- The default spring-boot-starter-camunda-sdk targets Spring Boot 3; the SDK ships
+             a dedicated Spring Boot 4 starter that must be used under Spring Boot 4. -->
+        <camunda.spring-boot.starter.artifactId>camunda-spring-boot-4-starter</camunda.spring-boot.starter.artifactId>
+        <!-- Spring Boot 4 / Spring Framework 7 require JUnit 6. The root pom imports
+             junit-bom before spring-boot-dependencies, so its version wins; align it
+             with the JUnit version managed by spring-boot-dependencies 4.0.1 (6.0.1)
+             to avoid NoSuchMethodError from SpringExtension against JUnit 5 APIs. -->
+        <dependency.junit.version>6.0.1</dependency.junit.version>
+        <dependency.spring-boot.version>4.0.1</dependency.spring-boot.version>
       </properties>
     </profile>
   </profiles>

--- a/spring-test/testcontainer/pom.xml
+++ b/spring-test/testcontainer/pom.xml
@@ -32,7 +32,7 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>spring-boot-starter-camunda-sdk</artifactId>
+      <artifactId>${camunda.spring-boot.starter.artifactId}</artifactId>
       <scope>test</scope>
       <exclusions>
         <!-- we don't want actuator autoconfiguration for testing -->


### PR DESCRIPTION
## Description

Adds Spring Boot 4 test coverage to `stable/8.7`, which previously had **none** (the CI matrix only tested the default Spring Boot version and `3.5`). Spring Boot 4 was part of the broader support initiative (camunda/camunda#41279).

Mirrors the `stable/8.8` setup (camunda/zeebe-process-test#2307), adapted to 8.7's SDK artifact naming:

- New `spring-boot-4.0` Maven profile on the spring-test modules selecting:
  - Spring Boot **4.0.1**
  - JUnit **6.0.1** (Spring Framework 7 requires JUnit 6; `SpringExtension` calls `ExtensionContext.Store.computeIfAbsent(...)`, absent in JUnit 5 → `NoSuchMethodError`)
  - the dedicated **`camunda-spring-boot-4-starter`** — the default `spring-boot-starter-camunda-sdk` targets Spring Boot 3 and fails under SB4 with `@ConditionalOnMissingBean ... BeanTypeDeductionException` on `ZeebeActuatorConfiguration`. Selected via a `camunda.spring-boot.starter.artifactId` property the profile overrides; the default build is unchanged.
- `4.0` added to both CI matrices (quoted, so YAML doesn't coerce it to `4` and miss the profile — the bug fixed for 8.8 in #2307).

> Note: on 8.7 the Spring Boot 3 SDK artifact is `spring-boot-starter-camunda-sdk` (on 8.8 it's `camunda-spring-boot-starter`).

## Verification (local, `-P spring-boot-4.0`)
- Embedded module test suite **passes** (spring-test + engine + assertions).
- Resolution confirmed: SB4 profile → `camunda-spring-boot-4-starter:8.7.30` + JUnit 6.0.1; default build → `spring-boot-starter-camunda-sdk` + JUnit 5.10.2.
- The testcontainers SB4 job needs Docker and is verified by CI here.

## Related
- `stable/8.8` equivalent: camunda/zeebe-process-test#2307
- Tracking issue: camunda/zeebe-process-test#2306
- Docs: camunda/camunda-docs#9040

🤖 Generated with [Claude Code](https://claude.com/claude-code)
