### PR TITLE
fix: pass fetch variables as set to JobActivationProperties

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGateway.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/GrpcToLogStreamGateway.java
@@ -107,6 +107,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
+import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 
 class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
@@ -169,7 +170,10 @@ class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase {
     jobActivationProperties
         .setWorker(worker, 0, worker.capacity())
         .setTimeout(request.getTimeout())
-        .setFetchVariables(request.getFetchVariableList().stream().map(StringValue::new).toList())
+        .setFetchVariables(
+            request.getFetchVariableList().stream()
+                .map(StringValue::new)
+                .collect(Collectors.toUnmodifiableSet()))
         .setTenantIds(request.getTenantIdsList());
 
     jobStreamer.addStream(jobType, jobActivationProperties, consumer);


### PR DESCRIPTION
## Description

The [8.7.31 release build](https://github.com/camunda/zeebe-process-test/actions/runs/27257284234) fails to compile the engine module:

```
GrpcToLogStreamGateway.java:[172,96] incompatible types: java.util.List<io.camunda.zeebe.msgpack.value.StringValue> cannot be converted to java.util.Set<io.camunda.zeebe.msgpack.value.StringValue>
```

**Root cause:** camunda/camunda@451621ab ("fix: deduplicate fetchVariables in StreamActivatedJobs requests", merged to `stable/8.7` on 2026-06-09) changed `JobActivationPropertiesImpl#setFetchVariables` from `Collection<StringValue>` to `Set<StringValue>`. The Zeebe 8.7.31 artifacts include that change, so `GrpcToLogStreamGateway#streamActivatedJobs` no longer compiles.

**Fix:** Collect the fetch variables into an unmodifiable set, mirroring the upstream adaptation of `RequestMapper#toJobActivationProperties` in the same commit.

## Verification

- `mvn -pl engine -am compile` against Zeebe 8.7.31 passes (previously failed with the exact CI error)
- `mvn -pl engine spotless:check` passes
- `EngineClientTest#shouldStreamJobs` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)