### PR TITLE
fix: revert agrona to 1.23.1 (binary incompatible with zeebe-scheduler)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -743,6 +743,7 @@
         <version>${plugin.version.surefire}</version>
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
+          <argLine>--add-opens java.base/jdk.internal.misc=ALL-UNNAMED</argLine>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -743,7 +743,7 @@
         <version>${plugin.version.surefire}</version>
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
-          <argLine>--add-opens java.base/jdk.internal.misc=ALL-UNNAMED</argLine>
+          <argLine>@{argLine} --add-opens java.base/jdk.internal.misc=ALL-UNNAMED</argLine>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
   </scm>
 
   <properties>
-    <dependency.agrona.version>2.4.1</dependency.agrona.version>
+    <dependency.agrona.version>1.23.1</dependency.agrona.version>
     <dependency.assertj.version>3.27.7</dependency.assertj.version>
     <dependency.awaitility.version>4.3.0</dependency.awaitility.version>
     <dependency.bytebuddy.version>1.18.10-jdk5</dependency.bytebuddy.version>
@@ -743,7 +743,7 @@
         <version>${plugin.version.surefire}</version>
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
-          <argLine>@{argLine} --add-opens java.base/jdk.internal.misc=ALL-UNNAMED</argLine>
+
         </configuration>
       </plugin>
 


### PR DESCRIPTION
## Problem

All tests on `main` have been failing since June 13 with:

```
java.lang.ClassNotFoundException: org.agrona.UnsafeAccess
```

Root cause: Renovate bumped `agrona` from `1.23.1` → `2.4.1` in PR #2292 (June 2). agrona 2.x **renamed** `org.agrona.UnsafeAccess` → `org.agrona.UnsafeApi`. The `zeebe-scheduler` jar was compiled against agrona 1.x and references the old class name — binary incompatible at runtime regardless of JVM flags.

`stable/8.9` remains on `1.23.1` and passes.

## Fix

Revert `dependency.agrona.version` to `1.23.1`. The 2.x bump can only be adopted once zeebe-scheduler (and other zeebe deps) are also compiled against agrona 2.x.