### PR TITLE
build: bump community-hub-release-parent 2.0.3 → 2.1.0 (fix Sonatype Central publish)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.camunda.community</groupId>
     <artifactId>community-hub-release-parent</artifactId>
-    <version>2.0.3</version>
+    <version>2.1.0</version>
   </parent>
 
   <groupId>io.camunda</groupId>


### PR DESCRIPTION
## Summary

Bump `org.camunda.community:community-hub-release-parent` from **2.0.3 → 2.1.0** to fix the Maven Central release failure.

## Background

The 8.7.33 release ([run 27685456681](https://github.com/camunda/zeebe-process-test/actions/runs/27685456681/job/81887010755#step:12:6249)) failed in the publish step:

```
Failed to execute goal org.sonatype.central:central-publishing-maven-plugin:0.7.0:publish
(injected-central-publishing) ... UnrecognizedPropertyException: Unrecognized field "warnings"
(class org.sonatype.central.publisher.client.model.DeploymentApiResponse)
```

Sonatype Central Portal now returns a `warnings` field in its deploy response; `central-publishing-maven-plugin:0.7.0` (pinned by parent `2.0.3`) cannot deserialize it. Parent `2.1.0` pins `0.8.0` in the `central-sonatype-publish` profile — the profile that governs the failing `injected-central-publishing` execution.

## Why parent bump (not a property override)

The plugin version is hardcoded `<version>0.7.0</version>` inside the parent's profile, so a child pom property override is unreliable. The `2.0.3 → 2.1.0` diff is fully contained to the `central-sonatype-publish` profile (plugin `0.7.0→0.8.0`, deploy-name property rework, `checksums=required`) — no unrelated changes.

## Why `stable/8.7` is patched directly

This isn't a forward-fix that needs to flow from `main` — `main` already carries the fix. The bump only needs to reach the lagging maintenance branches:

| branch | `community-hub-release-parent` | status |
|---|---|---|
| `main` | `2.1.0` | ✅ already has the fix |
| `stable/8.9` | `2.1.0` | ✅ already |
| `stable/8.8` | `2.1.0` | ✅ already |
| **`stable/8.7`** | `2.0.3` | ⬅️ **this PR** |

`stable/8.7` is the branch the failing **8.7.33** release runs from, so it's patched directly as a targeted backport to unblock that release. The change is a one-line parent version bump with nothing to cherry-pick from `main`, so a direct commit to the maintenance branch is the cleanest path.

## Test plan

- [ ] Re-run the release / a dry-run that exercises the Central publish step and confirm it deserializes the `warnings` response successfully.
