### PR TITLE
ci: Exclude main from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,7 @@
   ],
   "commitMessagePrefix": "deps:",
   "baseBranchPatterns": [
-    "/^stable\\/8\\.([6-9]|[1-9][0-9])/",
-    "main"
+    "/^stable\\/8\\.([6-9]|[1-9][0-9])/"
   ],
   "dependencyDashboard": true,
   "prConcurrentLimit": 30,


### PR DESCRIPTION
## Description

Disable Renovate update on the main branch.

We don't plan to release any new 8.10 version.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda/zeebe-process-test/issues/2335

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
