### PR TITLE
build: Update httpclient5 to 5.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,9 @@
     <dependency.feel.version>1.20.2</dependency.feel.version>
     <dependency.findbugs.version>3.0.2</dependency.findbugs.version>
     <dependency.guava.version>33.5.0-jre</dependency.guava.version>
+    <!-- Align with zeebe-client-java requirements; Spring Boot 4.0.6 pins older versions -->
+    <dependency.httpclient5.version>5.6.1</dependency.httpclient5.version>
+    <dependency.httpcore5.version>5.4.2</dependency.httpcore5.version>
     <dependency.immutables.version>2.12.2</dependency.immutables.version>
     <dependency.jackson.version>2.21.4</dependency.jackson.version>
     <dependency.javax.version>1.3.2</dependency.javax.version>
@@ -510,6 +513,27 @@
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
         <version>${dependency.checker-qual.version}</version>
+      </dependency>
+
+      <!--
+        Override Spring Boot 4.x managed httpclient5/httpcore5 versions.
+        Spring Boot 4.0.6 pins httpclient5=5.5.2 and httpcore5=5.3.6, but
+        zeebe-client-java requires httpclient5>=5.6.0
+      -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>${dependency.httpclient5.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
+        <version>${dependency.httpcore5.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-h2</artifactId>
+        <version>${dependency.httpcore5.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

Align httpclient5 and httpcore5 versions with [zeebe-client-java requirements](https://github.com/camunda/camunda/blob/stable/8.9/parent/pom.xml#L65-L66).

## Related issues

Caused by the dependency update of the `httpclient5` in https://github.com/camunda/camunda/commit/43afa398ad60318a6df62de62acf76dcfed7f86f. 

Fix failing CI builds https://github.com/camunda/zeebe-process-test/actions/runs/28001946221/job/82875920288#logs.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
