### PR TITLE
ci: Block releases for 8.10

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -87,6 +87,14 @@ jobs:
       - name: Output inputs
         run: echo "${{ toJSON(inputs) }}"
 
+      - name: Validate release version is not 8.10
+        run: |
+          set -euo pipefail
+          if [[ "${MINOR_VERSION}" == "8.10" ]] || [[ "${RELEASE_VERSION}" =~ ^8\.10\. ]]; then
+            echo "::error::Releases for version 8.10 are disabled while this repository is in maintenance mode. Only bugfix releases for older versions are allowed."
+            exit 1
+          fi
+
       # This step generates a GitHub App token to be used in Git operations as a workaround  for
       # the known GitHub issue described in https://github.com/camunda/camunda/issues/28522
       - name: Generate GitHub token


### PR DESCRIPTION
## Description

Add a new step to the release workflow to block releases for the 8.10 version. 

The repository is in maintenance mode. We want to build only patch releases for previous versions.

CI test run: https://github.com/camunda/zeebe-process-test/actions/runs/28086831569/job/83154751912

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda/zeebe-process-test/issues/2335

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
