### PR TITLE
[Backport stable/8.9] Deprecate ZeebeProcessTest, ZeebeProcessTestExtension, ZeebeSpringTest, and ZeebeTestExecutionListener since 8.8

### DIFF
--- a/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTest.java
+++ b/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTest.java
@@ -59,8 +59,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @since Java 8
  * @deprecated This annotation is deprecated since version 8.8 and will be removed in a future
  *     release. Use <a
- *     href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda Process
- *     Test</a> instead.
+ *     href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda
+ *     Process Test</a> instead.
  */
 @Deprecated
 @Target(ElementType.TYPE)

--- a/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTest.java
+++ b/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTest.java
@@ -57,7 +57,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * </ul>
  *
  * @since Java 8
- * @deprecated This annotation is deprecated since Camunda 8.8 and will be removed in a future
+ * @deprecated This annotation is deprecated since ZPT 8.8 and will be removed in a future
  *     release. Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
  *     Process Test</a> instead.
  */

--- a/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTest.java
+++ b/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTest.java
@@ -59,7 +59,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @since Java 8
  * @deprecated This annotation is deprecated since version 8.8 and will be removed in a future
  *     release. Use <a
- *     href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda Process
+ *     href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda Process
  *     Test</a> instead.
  */
 @Deprecated

--- a/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTest.java
+++ b/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTest.java
@@ -58,8 +58,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @since Java 8
  * @deprecated This annotation is deprecated since version 8.8 and will be removed in a future
- *     release. Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
- *     Process Test</a> instead.
+ *     release. Use <a
+ *     href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda Process
+ *     Test</a> instead.
  */
 @Deprecated
 @Target(ElementType.TYPE)

--- a/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTest.java
+++ b/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTest.java
@@ -57,7 +57,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * </ul>
  *
  * @since Java 8
+ * @deprecated This annotation is deprecated since Camunda 8.8 and will be removed in a future
+ *     release. Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
+ *     Process Test</a> instead.
  */
+@Deprecated
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited

--- a/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTest.java
+++ b/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTest.java
@@ -57,7 +57,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * </ul>
  *
  * @since Java 8
- * @deprecated This annotation is deprecated since ZPT 8.8 and will be removed in a future
+ * @deprecated This annotation is deprecated since version 8.8 and will be removed in a future
  *     release. Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
  *     Process Test</a> instead.
  */

--- a/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTestExtension.java
+++ b/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTestExtension.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * This extension is used by the {@link ZeebeProcessTest} annotation. It is responsible for managing
  * the lifecycle of the test engine.
  *
- * @deprecated This class is deprecated since ZPT 8.8 and will be removed in a future release.
+ * @deprecated This class is deprecated since version 8.8 and will be removed in a future release.
  *     Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
  *     Process Test</a> instead.
  */

--- a/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTestExtension.java
+++ b/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTestExtension.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  * the lifecycle of the test engine.
  *
  * @deprecated This class is deprecated since version 8.8 and will be removed in a future release.
- *     Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
+ *     Use <a href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda
  *     Process Test</a> instead.
  */
 @Deprecated

--- a/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTestExtension.java
+++ b/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTestExtension.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * This extension is used by the {@link ZeebeProcessTest} annotation. It is responsible for managing
  * the lifecycle of the test engine.
  *
- * @deprecated This class is deprecated since Camunda 8.8 and will be removed in a future release.
+ * @deprecated This class is deprecated since ZPT 8.8 and will be removed in a future release.
  *     Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
  *     Process Test</a> instead.
  */

--- a/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTestExtension.java
+++ b/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTestExtension.java
@@ -38,7 +38,8 @@ import org.slf4j.LoggerFactory;
  * the lifecycle of the test engine.
  *
  * @deprecated This class is deprecated since version 8.8 and will be removed in a future release.
- *     Use <a href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda
+ *     Use <a
+ *     href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda
  *     Process Test</a> instead.
  */
 @Deprecated

--- a/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTestExtension.java
+++ b/extension-testcontainer/src/main/java/io/camunda/zeebe/process/test/extension/testcontainer/ZeebeProcessTestExtension.java
@@ -36,7 +36,12 @@ import org.slf4j.LoggerFactory;
 /**
  * This extension is used by the {@link ZeebeProcessTest} annotation. It is responsible for managing
  * the lifecycle of the test engine.
+ *
+ * @deprecated This class is deprecated since Camunda 8.8 and will be removed in a future release.
+ *     Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
+ *     Process Test</a> instead.
  */
+@Deprecated
 public class ZeebeProcessTestExtension
     implements BeforeEachCallback, AfterEachCallback, BeforeAllCallback, TestWatcher {
 

--- a/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTest.java
+++ b/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTest.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * </ul>
  *
  * @since Java 21
- * @deprecated This annotation is deprecated since ZPT 8.8 and will be removed in a future
+ * @deprecated This annotation is deprecated since version 8.8 and will be removed in a future
  *     release. Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
  *     Process Test</a> instead.
  */

--- a/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTest.java
+++ b/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTest.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * </ul>
  *
  * @since Java 21
- * @deprecated This annotation is deprecated since Camunda 8.8 and will be removed in a future
+ * @deprecated This annotation is deprecated since ZPT 8.8 and will be removed in a future
  *     release. Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
  *     Process Test</a> instead.
  */

--- a/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTest.java
+++ b/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @since Java 21
  * @deprecated This annotation is deprecated since version 8.8 and will be removed in a future
  *     release. Use <a
- *     href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda Process
+ *     href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda Process
  *     Test</a> instead.
  */
 @Deprecated(forRemoval = true, since = "8.8")

--- a/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTest.java
+++ b/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTest.java
@@ -46,7 +46,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * </ul>
  *
  * @since Java 21
+ * @deprecated This annotation is deprecated since Camunda 8.8 and will be removed in a future
+ *     release. Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
+ *     Process Test</a> instead.
  */
+@Deprecated(forRemoval = true, since = "8.8")
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited

--- a/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTest.java
+++ b/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTest.java
@@ -48,8 +48,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @since Java 21
  * @deprecated This annotation is deprecated since version 8.8 and will be removed in a future
  *     release. Use <a
- *     href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda Process
- *     Test</a> instead.
+ *     href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda
+ *     Process Test</a> instead.
  */
 @Deprecated(forRemoval = true, since = "8.8")
 @Target(ElementType.TYPE)

--- a/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTest.java
+++ b/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTest.java
@@ -47,8 +47,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @since Java 21
  * @deprecated This annotation is deprecated since version 8.8 and will be removed in a future
- *     release. Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
- *     Process Test</a> instead.
+ *     release. Use <a
+ *     href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda Process
+ *     Test</a> instead.
  */
 @Deprecated(forRemoval = true, since = "8.8")
 @Target(ElementType.TYPE)

--- a/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtension.java
+++ b/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtension.java
@@ -30,7 +30,8 @@ import org.slf4j.LoggerFactory;
  * the lifecycle of the test engine.
  *
  * @deprecated This class is deprecated since version 8.8 and will be removed in a future release.
- *     Use <a href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda
+ *     Use <a
+ *     href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda
  *     Process Test</a> instead.
  */
 @Deprecated(forRemoval = true, since = "8.8")

--- a/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtension.java
+++ b/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtension.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * the lifecycle of the test engine.
  *
  * @deprecated This class is deprecated since version 8.8 and will be removed in a future release.
- *     Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
+ *     Use <a href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda
  *     Process Test</a> instead.
  */
 @Deprecated(forRemoval = true, since = "8.8")

--- a/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtension.java
+++ b/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtension.java
@@ -28,7 +28,12 @@ import org.slf4j.LoggerFactory;
 /**
  * This extension is used by the {@link ZeebeProcessTest} annotation. It is responsible for managing
  * the lifecycle of the test engine.
+ *
+ * @deprecated This class is deprecated since Camunda 8.8 and will be removed in a future release.
+ *     Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
+ *     Process Test</a> instead.
  */
+@Deprecated(forRemoval = true, since = "8.8")
 public class ZeebeProcessTestExtension
     implements BeforeEachCallback, AfterEachCallback, TestWatcher {
 

--- a/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtension.java
+++ b/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtension.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * This extension is used by the {@link ZeebeProcessTest} annotation. It is responsible for managing
  * the lifecycle of the test engine.
  *
- * @deprecated This class is deprecated since Camunda 8.8 and will be removed in a future release.
+ * @deprecated This class is deprecated since ZPT 8.8 and will be removed in a future release.
  *     Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
  *     Process Test</a> instead.
  */

--- a/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtension.java
+++ b/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtension.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * This extension is used by the {@link ZeebeProcessTest} annotation. It is responsible for managing
  * the lifecycle of the test engine.
  *
- * @deprecated This class is deprecated since ZPT 8.8 and will be removed in a future release.
+ * @deprecated This class is deprecated since version 8.8 and will be removed in a future release.
  *     Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
  *     Process Test</a> instead.
  */

--- a/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
+++ b/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
@@ -28,7 +28,7 @@ import org.springframework.test.context.TestExecutionListeners;
  *
  * @deprecated This annotation is deprecated since version 8.8 and will be removed in a future
  *     release. Use <a
- *     href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda Process
+ *     href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda Process
  *     Test</a> instead.
  */
 @Deprecated(forRemoval = true, since = "8.8")

--- a/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
+++ b/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
@@ -28,8 +28,8 @@ import org.springframework.test.context.TestExecutionListeners;
  *
  * @deprecated This annotation is deprecated since version 8.8 and will be removed in a future
  *     release. Use <a
- *     href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda Process
- *     Test</a> instead.
+ *     href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda
+ *     Process Test</a> instead.
  */
 @Deprecated(forRemoval = true, since = "8.8")
 @Target({ElementType.TYPE})

--- a/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
+++ b/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
@@ -27,8 +27,9 @@ import org.springframework.test.context.TestExecutionListeners;
  * Annotation for the Spring test.
  *
  * @deprecated This annotation is deprecated since version 8.8 and will be removed in a future
- *     release. Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
- *     Process Test</a> instead.
+ *     release. Use <a
+ *     href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda Process
+ *     Test</a> instead.
  */
 @Deprecated(forRemoval = true, since = "8.8")
 @Target({ElementType.TYPE})

--- a/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
+++ b/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
@@ -26,7 +26,7 @@ import org.springframework.test.context.TestExecutionListeners;
 /**
  * Annotation for the Spring test.
  *
- * @deprecated This annotation is deprecated since Camunda 8.8 and will be removed in a future
+ * @deprecated This annotation is deprecated since ZPT 8.8 and will be removed in a future
  *     release. Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
  *     Process Test</a> instead.
  */

--- a/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
+++ b/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
@@ -23,7 +23,14 @@ import java.lang.annotation.Target;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestExecutionListeners;
 
-/** Annotation for the Spring test. */
+/**
+ * Annotation for the Spring test.
+ *
+ * @deprecated This annotation is deprecated since Camunda 8.8 and will be removed in a future
+ *     release. Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
+ *     Process Test</a> instead.
+ */
+@Deprecated(forRemoval = true, since = "8.8")
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited

--- a/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
+++ b/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
@@ -26,7 +26,7 @@ import org.springframework.test.context.TestExecutionListeners;
 /**
  * Annotation for the Spring test.
  *
- * @deprecated This annotation is deprecated since ZPT 8.8 and will be removed in a future
+ * @deprecated This annotation is deprecated since version 8.8 and will be removed in a future
  *     release. Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
  *     Process Test</a> instead.
  */

--- a/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
+++ b/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
@@ -29,7 +29,8 @@ import org.springframework.test.context.TestExecutionListener;
  * Test execution listener binding the Zeebe engine to current test context.
  *
  * @deprecated This class is deprecated since version 8.8 and will be removed in a future release.
- *     Use <a href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda
+ *     Use <a
+ *     href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda
  *     Process Test</a> instead.
  */
 @Deprecated(forRemoval = true, since = "8.8")

--- a/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
+++ b/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
@@ -29,7 +29,7 @@ import org.springframework.test.context.TestExecutionListener;
  * Test execution listener binding the Zeebe engine to current test context.
  *
  * @deprecated This class is deprecated since version 8.8 and will be removed in a future release.
- *     Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
+ *     Use <a href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda
  *     Process Test</a> instead.
  */
 @Deprecated(forRemoval = true, since = "8.8")

--- a/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
+++ b/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
@@ -28,7 +28,7 @@ import org.springframework.test.context.TestExecutionListener;
 /**
  * Test execution listener binding the Zeebe engine to current test context.
  *
- * @deprecated This class is deprecated since ZPT 8.8 and will be removed in a future release.
+ * @deprecated This class is deprecated since version 8.8 and will be removed in a future release.
  *     Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
  *     Process Test</a> instead.
  */

--- a/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
+++ b/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
@@ -25,7 +25,14 @@ import org.springframework.lang.NonNull;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 
-/** Test execution listener binding the Zeebe engine to current test context. */
+/**
+ * Test execution listener binding the Zeebe engine to current test context.
+ *
+ * @deprecated This class is deprecated since Camunda 8.8 and will be removed in a future release.
+ *     Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
+ *     Process Test</a> instead.
+ */
+@Deprecated(forRemoval = true, since = "8.8")
 public class ZeebeTestExecutionListener extends AbstractZeebeTestExecutionListener
     implements TestExecutionListener, Ordered {
 

--- a/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
+++ b/spring-test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
@@ -28,7 +28,7 @@ import org.springframework.test.context.TestExecutionListener;
 /**
  * Test execution listener binding the Zeebe engine to current test context.
  *
- * @deprecated This class is deprecated since Camunda 8.8 and will be removed in a future release.
+ * @deprecated This class is deprecated since ZPT 8.8 and will be removed in a future release.
  *     Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
  *     Process Test</a> instead.
  */

--- a/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
+++ b/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
@@ -28,7 +28,7 @@ import org.springframework.test.context.TestExecutionListeners;
  *
  * @deprecated This annotation is deprecated since version 8.8 and will be removed in a future
  *     release. Use <a
- *     href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda Process
+ *     href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda Process
  *     Test</a> instead.
  */
 @Deprecated(forRemoval = true, since = "8.8")

--- a/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
+++ b/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
@@ -28,8 +28,8 @@ import org.springframework.test.context.TestExecutionListeners;
  *
  * @deprecated This annotation is deprecated since version 8.8 and will be removed in a future
  *     release. Use <a
- *     href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda Process
- *     Test</a> instead.
+ *     href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda
+ *     Process Test</a> instead.
  */
 @Deprecated(forRemoval = true, since = "8.8")
 @Target({ElementType.TYPE})

--- a/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
+++ b/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
@@ -27,8 +27,9 @@ import org.springframework.test.context.TestExecutionListeners;
  * Annotation for the Spring test.
  *
  * @deprecated This annotation is deprecated since version 8.8 and will be removed in a future
- *     release. Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
- *     Process Test</a> instead.
+ *     release. Use <a
+ *     href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda Process
+ *     Test</a> instead.
  */
 @Deprecated(forRemoval = true, since = "8.8")
 @Target({ElementType.TYPE})

--- a/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
+++ b/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
@@ -26,7 +26,7 @@ import org.springframework.test.context.TestExecutionListeners;
 /**
  * Annotation for the Spring test.
  *
- * @deprecated This annotation is deprecated since Camunda 8.8 and will be removed in a future
+ * @deprecated This annotation is deprecated since ZPT 8.8 and will be removed in a future
  *     release. Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
  *     Process Test</a> instead.
  */

--- a/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
+++ b/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
@@ -23,7 +23,14 @@ import java.lang.annotation.Target;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestExecutionListeners;
 
-/** Annotation for the Spring test. */
+/**
+ * Annotation for the Spring test.
+ *
+ * @deprecated This annotation is deprecated since Camunda 8.8 and will be removed in a future
+ *     release. Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
+ *     Process Test</a> instead.
+ */
+@Deprecated(forRemoval = true, since = "8.8")
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited

--- a/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
+++ b/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
@@ -26,7 +26,7 @@ import org.springframework.test.context.TestExecutionListeners;
 /**
  * Annotation for the Spring test.
  *
- * @deprecated This annotation is deprecated since ZPT 8.8 and will be removed in a future
+ * @deprecated This annotation is deprecated since version 8.8 and will be removed in a future
  *     release. Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
  *     Process Test</a> instead.
  */

--- a/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
+++ b/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
@@ -29,7 +29,7 @@ import org.springframework.test.context.TestExecutionListener;
 /**
  * Test execution listener binding the Zeebe engine to current test context.
  *
- * @deprecated This class is deprecated since ZPT 8.8 and will be removed in a future release.
+ * @deprecated This class is deprecated since version 8.8 and will be removed in a future release.
  *     Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
  *     Process Test</a> instead.
  */

--- a/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
+++ b/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
@@ -30,7 +30,7 @@ import org.springframework.test.context.TestExecutionListener;
  * Test execution listener binding the Zeebe engine to current test context.
  *
  * @deprecated This class is deprecated since version 8.8 and will be removed in a future release.
- *     Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
+ *     Use <a href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda
  *     Process Test</a> instead.
  */
 @Deprecated(forRemoval = true, since = "8.8")

--- a/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
+++ b/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
@@ -30,7 +30,8 @@ import org.springframework.test.context.TestExecutionListener;
  * Test execution listener binding the Zeebe engine to current test context.
  *
  * @deprecated This class is deprecated since version 8.8 and will be removed in a future release.
- *     Use <a href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda
+ *     Use <a
+ *     href="https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-process-test/">Camunda
  *     Process Test</a> instead.
  */
 @Deprecated(forRemoval = true, since = "8.8")

--- a/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
+++ b/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
@@ -29,7 +29,7 @@ import org.springframework.test.context.TestExecutionListener;
 /**
  * Test execution listener binding the Zeebe engine to current test context.
  *
- * @deprecated This class is deprecated since Camunda 8.8 and will be removed in a future release.
+ * @deprecated This class is deprecated since ZPT 8.8 and will be removed in a future release.
  *     Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
  *     Process Test</a> instead.
  */

--- a/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
+++ b/spring-test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
@@ -26,7 +26,14 @@ import org.springframework.lang.NonNull;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 
-/** Test execution listener binding the Zeebe engine to current test context. */
+/**
+ * Test execution listener binding the Zeebe engine to current test context.
+ *
+ * @deprecated This class is deprecated since Camunda 8.8 and will be removed in a future release.
+ *     Use <a href="https://docs.camunda.io/docs/apis-tools/testing/getting-started/">Camunda
+ *     Process Test</a> instead.
+ */
+@Deprecated(forRemoval = true, since = "8.8")
 public class ZeebeTestExecutionListener extends AbstractZeebeTestExecutionListener
     implements TestExecutionListener, Ordered {
 


### PR DESCRIPTION
# Description
Backport of #2348 to `stable/8.9`.

relates to 