### PR TITLE
ci: Update Slack webhook secret in CI workflow

### DIFF
--- a/.github/workflows/snapshot-test.yml
+++ b/.github/workflows/snapshot-test.yml
@@ -85,29 +85,40 @@ jobs:
         run: |
           FAILED=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs --paginate --jq '[.jobs[] | select(.conclusion == "failure") | .name | capture("\\((?<branch>[^)]+)\\)") | .branch] | unique | join(", ")')
           echo "branches=$FAILED" >> $GITHUB_OUTPUT
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_CPT_ZPT_CI_WEBHOOK;    
       - id: slack-notify
         name: Send slack notification
         uses: slackapi/slack-github-action@v3.0.3
+        if: steps.secrets.outputs.SLACK_CPT_ZPT_CI_WEBHOOK != ''
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ steps.secrets.outputs.SLACK_CPT_ZPT_CI_WEBHOOK }}
           webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {
-              "text": ":alarm: `zeebe-process-test` build against Zeebe SNAPSHOT version failed! :alarm:",
               "blocks": [
                 {
+                   "type": "section",
+                   "text": {
+                     "type": "mrkdwn",
+                     "text": ":alarm: *Zeebe Process Test (ZPT) Compatibility Tests Failed*"
+                   }
+                 },
+                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":alarm: `zeebe-process-test` build against Zeebe SNAPSHOT version failed! :alarm:\n\nFailed branches: `${{ steps.failed-branches.outputs.branches }}`"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Please check: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": "Branches: `${{ steps.failed-branches.outputs.branches }}`\nZeebe version: `SNAPSHOT`\nPlease check: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]

--- a/.github/workflows/snapshot-test.yml
+++ b/.github/workflows/snapshot-test.yml
@@ -76,7 +76,7 @@ jobs:
     name: Send slack notification on build failure
     runs-on: ubuntu-latest
     needs: [test-against-zeebe-snapshot]
-    if: failure()
+    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
     steps:
       - name: Get failed branches
         id: failed-branches


### PR DESCRIPTION
## Description

Change the Slack webhook from `secrets.SLACK_WEBHOOK_URL` to `SLACK_CPT_ZPT_CI_WEBHOOK` from Vault.

Align message format with a similar CPT message. 

## Related issues

Related [Slack discussion](https://camunda.slack.com/archives/C08NZ7E9ZT2/p1783601445705269).

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
